### PR TITLE
Refactor database, add background jobs, and improve error handling

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -8,24 +8,37 @@
   ```bash
   export SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
   ```
+  Mit `PDF_ANNOTATOR_BEHIND_PROXY=1` ist `SECRET_KEY` **zwingend** — die App
+  bricht sonst beim Start mit einem Fehler ab. Ohne das Flag wird ein
+  fehlender Key automatisch generiert und unter `<data_dir>/secret_key`
+  (0600) persistiert (Sessions überleben Neustarts, Worker teilen den Key).
 
-- [ ] **CSRF-Protection** aktiviert (Flask-WTF installieren)
-  ```bash
-  uv add flask-wtf
-  ```
+- [ ] **PDF_ANNOTATOR_BEHIND_PROXY=1** gesetzt, wenn die App hinter einem
+  TLS-terminierenden Reverse Proxy läuft — aktiviert ProxyFix
+  (`X-Forwarded-For/Proto/Host`, 1 Hop), Secure-Session-Cookies, HSTS und
+  https-URL-Schema. Niemals setzen, wenn kein vertrauenswürdiger Proxy
+  davor steht (Header wären sonst angreifbar).
+
+- [ ] **Registrierung absichern** — nach dem Anlegen der benötigten Accounts
+  `PDF_ANNOTATOR_REGISTRATION=0` setzen (der erste Benutzer darf sich immer
+  registrieren) und/oder einen `PDF_ANNOTATOR_INVITE_CODE` vergeben
+
+- [ ] **CSRF-Protection** aktiv (Flask-WTF ist integriert; alle POST/DELETE
+  Endpoints erfordern einen CSRF-Token — auch `save_annotation`)
 
 - [ ] **HTTPS** konfiguriert (Let's Encrypt/Cloudflare)
   - Alle HTTP Requests zu HTTPS umleiten
-  - HSTS Header aktivieren
+  - HSTS Header aktivieren (setzt die App mit `PDF_ANNOTATOR_BEHIND_PROXY=1` selbst)
 
 - [ ] **Firewall** konfiguriert
   - Nur notwendige Ports öffnen (443, 80 für Redirect)
   - Administrativen Zugang beschränken
 
-- [ ] **Rate Limiting** implementieren (Flask-Limiter)
-  ```bash
-  uv add flask-limiter
-  ```
+- [ ] **Rate Limiting** konfiguriert (Flask-Limiter ist integriert;
+  Standard-Storage `memory://` ist pro Worker-Prozess — Limits
+  multiplizieren sich mit der Worker-Anzahl und werden bei Neustart
+  zurückgesetzt. Für harte Limits `RATELIMIT_STORAGE_URI` auf einen
+  gemeinsamen Store zeigen lassen, z.B. `redis://host:6379`)
 
 ### ✅ Konfiguration
 
@@ -116,6 +129,8 @@ uv sync
 # Umgebungsvariablen setzen
 export FLASK_ENV=production
 export SECRET_KEY="YOUR_SECURE_RANDOM_SECRET_KEY"
+# Hinter dem Nginx-Reverse-Proxy (siehe Schritt 6): Pflicht!
+export PDF_ANNOTATOR_BEHIND_PROXY=1
 export DATABASE_PATH="/var/www/pdfAnnotater/data/annotations.db"
 export UPLOAD_FOLDER="/var/www/pdfAnnotater/data/uploads"
 
@@ -222,22 +237,21 @@ server {
 
 ## Bekannte Sicherheitslücken (TODO)
 
-Diese müssen VOR Produktions-Deployment behoben werden:
+Behoben (integriert, keine Aktion nötig):
 
-### 🔴 KRITISCH
+- ✅ **CSRF-Protection** — Flask-WTF ist integriert; alle POST/DELETE
+  Endpoints (inkl. `save_annotation`) erfordern einen CSRF-Token
+- ✅ **Rate Limiting** — Flask-Limiter ist integriert (Storage via
+  `RATELIMIT_STORAGE_URI` konfigurierbar)
 
-1. **CSRF-Protection fehlt** - Alle POST/DELETE Endpoints anfällig
-   - **Fix**: Flask-WTF integrieren (siehe oben)
-
-2. **Rate Limiting fehlt** - DoS-anfällig
-   - **Fix**: Flask-Limiter installieren
+Noch offen:
 
 ### 🟡 WICHTIG
 
-3. **Session Management** - Keine Session-Timeouts
+1. **Session Management** - Keine Session-Timeouts
    - **Fix**: `PERMANENT_SESSION_LIFETIME` setzen
 
-4. **File Type Validation** - Nur Extension-Check
+2. **File Type Validation** - Nur Extension-Check
    - **Fix**: Magic Bytes prüfen mit `python-magic`
 
 ---
@@ -247,7 +261,9 @@ Diese müssen VOR Produktions-Deployment behoben werden:
 ### Regelmäßige Aufgaben
 
 - **Täglich**: Log-Files überprüfen
-- **Wöchentlich**: Disk Space überprüfen, alte Exports löschen
+- **Wöchentlich**: Disk Space überprüfen (alte Exports, abgelaufene
+  Hintergrund-Jobs und der Render-Cache werden automatisch vom
+  Cleanup-Thread aufgeräumt, der alle 15 Minuten läuft)
 - **Monatlich**: Security Updates installieren
 - **Quartalsweise**: Backup-Restore testen
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
 
 # exec replaces the shell so gunicorn receives SIGTERM directly (graceful shutdown).
 # Shell form is needed only for ${GUNICORN_WORKERS:-2} expansion.
-# Timeout default raised to 600s to cover synchronous OCR requests on
-# larger scanned documents (see services/ocr.py OCR_TIMEOUT_SECONDS).
-CMD ["sh", "-c", "exec python -m gunicorn --workers ${GUNICORN_WORKERS:-2} --bind 0.0.0.0:8000 --timeout ${GUNICORN_TIMEOUT:-600} --access-logfile - --error-logfile - wsgi:app"]
+# OCR and annotated-PDF export run as background jobs off the request
+# path; 120s covers the remaining synchronous heavy requests (ZIP
+# backup export/import of large libraries).
+CMD ["sh", "-c", "exec python -m gunicorn --workers ${GUNICORN_WORKERS:-2} --bind 0.0.0.0:8000 --timeout ${GUNICORN_TIMEOUT:-120} --access-logfile - --error-logfile - wsgi:app"]

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Eine Flask-basierte Web-Applikation zum Annotieren von PDF-Dokumenten mit Side-b
 - **PDF ersetzen:** PDF-Datei austauschen, alle Notizen bleiben erhalten
 - **Metadaten:** Vorname, Nachname, Titel, Jahr, Thema pro Dokument
 - **Export-Funktionen:**
-  - **Annotiertes PDF:** Original-PDF mit Notizen in gruener Courier-Schrift + Zeitstempel
+  - **Annotiertes PDF:** Original-PDF mit Notizen in gruener Courier-Schrift + Zeitstempel (laeuft als Hintergrund-Job mit Fortschritts-Polling)
   - **Markdown-Export:** Alle Notizen als strukturiertes Markdown-Dokument
 - **Zoom:** Stufenweises Zoomen (50%-200%) und Breitenanpassung
 - **Text markieren/kopieren:** PDF-Seiten haben eine unsichtbare Textebene, Text lässt sich wie in einem normalen Browser markieren und kopieren
 - **KI-Assistent (optional, deaktiviert per Default):** Notiztext mit freier Anweisung bearbeiten oder aus Stichpunkten generieren lassen ("✨ KI"), oder aus markiertem PDF-Text eine Notiz formulieren lassen ("✨ KI aus PDF"). Unterstützt Anthropic, OpenAI oder jeden OpenAI-kompatiblen Endpunkt (z.B. selbstgehostete Uni-Gateways)
 - **Bibliothekssuche ("🔎 SWB-Suche"):** Markierten PDF-Text direkt in deutschen Bibliothekskatalogen (SWB/K10plus/DNB/...) nachschlagen — öffnet die Treffer in einem neuen Tab, immer aktiv, kein Setup noetig
-- **OCR fuer gescannte Dokumente:** Erkennt Seiten ohne Textebene automatisch (Hinweis im Viewer) und fuegt per Klick eine durchsuchbare Textebene hinzu (tesseract erforderlich; im Docker-Image enthalten)
+- **OCR fuer gescannte Dokumente:** Erkennt Seiten ohne Textebene automatisch (Hinweis im Viewer) und fuegt per Klick eine durchsuchbare Textebene hinzu (tesseract erforderlich; im Docker-Image enthalten). Laeuft als Hintergrund-Job mit Fortschritts-Polling — der Viewer bleibt waehrenddessen bedienbar
 - **Ansicht-Umschalter:** PDF-Fokus / geteilte Ansicht / Notizen-Fokus fuer bessere Lesbarkeit, Einstellung bleibt erhalten
 - **Themes:** Light, Dark, Brutalist und Kompakt (platzsparend, maximale Flaeche fuer PDF und Notizen) — Einstellung wird pro Account serverseitig gespeichert
 - **Multi-User:** Registrierung und Login mit eigenem Dokumenten-Bereich
@@ -51,11 +51,14 @@ Die App ist unter `http://localhost:8000` erreichbar.
 
 > **Hinweis zum Produktionsbetrieb:** Im Container laeuft die App bereits
 > hinter **Gunicorn** (kein Flask-Dev-Server, siehe `Dockerfile`;
-> Worker-Anzahl via `GUNICORN_WORKERS`, Timeout via `GUNICORN_TIMEOUT`).
+> Worker-Anzahl via `GUNICORN_WORKERS`, Timeout via `GUNICORN_TIMEOUT`,
+> Standard 120 s — lange Vorgaenge wie OCR und PDF-Export laufen als
+> Hintergrund-Jobs und brauchen keinen hoeheren Timeout mehr).
 > Der Container terminiert aber **kein TLS** und sollte nicht direkt im
 > Internet exponiert werden — fuer den oeffentlichen Betrieb einen
 > **Reverse Proxy** (nginx, Caddy oder Traefik) davorschalten, der HTTPS
-> uebernimmt und `X-Forwarded-Proto` setzt (nginx-Beispiel siehe unten,
+> uebernimmt und `X-Forwarded-Proto` setzt, und in der App
+> `PDF_ANNOTATOR_BEHIND_PROXY=1` setzen (nginx-Beispiel siehe unten,
 > Abschnitt "Reverse Proxy").
 
 ### Persistenz
@@ -72,8 +75,13 @@ Umgebungsvariablen in einer `.env`-Datei oder direkt in der Shell:
 
 | Variable | Pflicht | Standard | Beschreibung |
 |---|---|---|---|
-| `SECRET_KEY` | **Ja** | — | Flask Session-Key (min. 32 zufaellige Bytes) |
+| `SECRET_KEY` | **Ja**¹ | — | Flask Session-Key (min. 32 zufaellige Bytes) |
+| `PDF_ANNOTATOR_BEHIND_PROXY` | Nein | — | `1` = App laeuft hinter einem TLS-terminierenden Reverse Proxy: aktiviert ProxyFix (`X-Forwarded-For/Proto/Host`, 1 Hop), Secure-Cookies, HSTS und https-URLs — und macht `SECRET_KEY` **zwingend** (harter Startfehler, falls nicht gesetzt) |
+| `PDF_ANNOTATOR_REGISTRATION` | Nein | `1` | `0` = Selbstregistrierung deaktivieren (der allererste Benutzer darf sich immer registrieren, damit der Admin-Account angelegt werden kann) |
+| `PDF_ANNOTATOR_INVITE_CODE` | Nein | — | Falls gesetzt: Registrierung nur mit diesem Einladungscode moeglich |
+| `RATELIMIT_STORAGE_URI` | Nein | `memory://` | Storage fuer Flask-Limiter. `memory://` ist pro Worker-Prozess (Limits multiplizieren sich mit der Worker-Anzahl und werden bei Neustart zurueckgesetzt); alternativ z.B. `redis://host:6379` |
 | `GUNICORN_WORKERS` | Nein | `2` | Anzahl Gunicorn Worker-Prozesse |
+| `GUNICORN_TIMEOUT` | Nein | `120` | Gunicorn Request-Timeout in Sekunden (OCR und PDF-Export laufen als Hintergrund-Jobs, ein hoher Timeout ist nicht mehr noetig) |
 | `AI_PROVIDER` | Nein | — (Funktion deaktiviert) | `anthropic` oder `openai` — aktiviert den KI-Assistenten im Notizfeld |
 | `AI_MODEL` | Nein | Provider-Default (`claude-haiku-4-5` / `gpt-4o-mini`) | Modell-Override |
 | `ANTHROPIC_API_KEY` | Falls `AI_PROVIDER=anthropic` | — | Anthropic API-Key |
@@ -81,6 +89,12 @@ Umgebungsvariablen in einer `.env`-Datei oder direkt in der Shell:
 | `OPENAI_BASE_URL` | Nein | `api.openai.com` | Alternativer OpenAI-kompatibler Endpunkt (z.B. ein Uni-Gateway) |
 
 Empfohlene Worker-Anzahl: `2 * CPU-Kerne + 1`.
+
+¹ **`SECRET_KEY`:** Mit `PDF_ANNOTATOR_BEHIND_PROXY=1` zwingend erforderlich
+(die App startet sonst nicht). Ohne das Flag (Desktop-App, Standalone-Server)
+wird bei fehlendem `SECRET_KEY` automatisch ein Key generiert und unter
+`<data_dir>/secret_key` (Rechte 0600) persistiert — Sessions ueberleben so
+Neustarts, und alle Gunicorn-Worker teilen sich den Key ueber das Daten-Volume.
 
 **Hinweis:** Ist `AI_PROVIDER` gesetzt, werden Notiztext und Anweisungen bei Nutzung des KI-Assistenten an den konfigurierten Drittanbieter gesendet — Datenschutz-relevant, daher standardmaessig deaktiviert.
 
@@ -98,7 +112,13 @@ docker compose up -d
 
 ### Reverse Proxy (nginx)
 
-Fuer HTTPS-Betrieb hinter nginx:
+Fuer HTTPS-Betrieb hinter nginx. In der App dazu `PDF_ANNOTATOR_BEHIND_PROXY=1`
+setzen — damit vertraut sie den `X-Forwarded-*`-Headern (ProxyFix, 1 Hop),
+setzt Session-Cookies mit `Secure`-Flag, sendet HSTS und erzeugt https-URLs.
+Achtung: Mit diesem Flag muss `SECRET_KEY` gesetzt sein, sonst bricht der
+Start mit einem Fehler ab. Empfehlung fuer oeffentlich erreichbare Instanzen:
+nach dem Anlegen der benoetigten Accounts `PDF_ANNOTATOR_REGISTRATION=0`
+setzen und/oder einen `PDF_ANNOTATOR_INVITE_CODE` vergeben.
 
 ```nginx
 server {
@@ -237,15 +257,20 @@ pdfAnnotater/
 ├── src/pdf_annotator/
 │   ├── app.py                  # Flask App Factory
 │   ├── config.py               # Konfiguration (Dev/Prod/Test), .env-Loading
+│   ├── forms.py                # Flask-WTF Formulare (Login/Registrierung/Passwort)
 │   ├── desktop.py              # Desktop-App Entry Point (flaskwebgui)
 │   │
 │   ├── models/
-│   │   ├── database.py         # SQLite Schema & CRUD
+│   │   ├── database.py         # SQLite CRUD (DatabaseManager, get_db)
+│   │   ├── migrations.py       # Versionierte Schema-Migrationen (PRAGMA user_version)
 │   │   └── user.py             # User-Modell (Flask-Login)
 │   │
 │   ├── services/
 │   │   ├── pdf_processor.py    # PDF → PNG Rendering + Text-Layer-Extraktion
 │   │   ├── pdf_generator.py    # Annotiertes PDF erstellen
+│   │   ├── render_cache.py     # Disk-Cache fuer Seiten-Renderings/Text-Layouts
+│   │   ├── jobs.py             # Hintergrund-Jobs (OCR, PDF-Export)
+│   │   ├── cleanup.py          # Periodische Wartung (Exports, Jobs, Cache)
 │   │   ├── ocr.py              # OCR via ocrmypdf/tesseract
 │   │   ├── ai_client.py        # KI-Assistent (Anthropic/OpenAI)
 │   │   ├── swb_client.py       # Bibliothekskatalog-Suche (swb)
@@ -254,11 +279,12 @@ pdfAnnotater/
 │   │   └── markdown_exporter.py
 │   │
 │   ├── routes/
+│   │   ├── _helpers.py         # Gemeinsame Route-Helper (Ownership, Fehler, JSON)
 │   │   ├── auth.py             # Login, Registrierung, Passwort-aendern, Theme
 │   │   ├── admin.py            # Admin Panel (Benutzerverwaltung)
 │   │   ├── upload.py           # PDF-Upload, Delete, Backup-Export/Import
-│   │   ├── viewer.py           # Viewer, Annotations-, Text-Layer- & OCR-API
-│   │   ├── export.py           # PDF-/Markdown-/Original-Export
+│   │   ├── viewer.py           # Viewer, Annotations-, Text-Layer-, OCR- & Job-Status-API
+│   │   ├── export.py           # PDF-/Markdown-/Original-Export + Job-Download
 │   │   ├── ai.py               # KI-Textbearbeitung
 │   │   └── swb.py              # Bibliothekssuche
 │   │
@@ -326,7 +352,26 @@ CREATE TABLE annotations (
     FOREIGN KEY (doc_id) REFERENCES documents(id) ON DELETE CASCADE,
     UNIQUE(doc_id, page_number)
 );
+
+CREATE TABLE jobs (                 -- Hintergrund-Jobs (OCR, PDF-Export)
+    id TEXT PRIMARY KEY,            -- UUID4
+    type TEXT NOT NULL,             -- 'ocr' | 'export_pdf'
+    doc_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',  -- pending|running|done|error
+    result_path TEXT,
+    result_json TEXT,
+    error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    started_at TIMESTAMP,
+    finished_at TIMESTAMP,
+    FOREIGN KEY (doc_id) REFERENCES documents(id) ON DELETE CASCADE
+);
 ```
+
+Das Schema ist ueber `PRAGMA user_version` versioniert (siehe
+`src/pdf_annotator/models/migrations.py`); `init_db()` migriert bestehende
+Datenbanken automatisch.
 
 ---
 
@@ -357,15 +402,17 @@ CREATE TABLE annotations (
 - `POST /viewer/api/metadata/<doc_id>` - Metadaten aktualisieren
 - `POST /viewer/api/replace/<doc_id>` - PDF ersetzen
 - `POST /viewer/api/append/<doc_id>` - Seiten aus anderer PDF anhaengen
-- `POST /viewer/api/ocr/<doc_id>` - OCR ausfuehren (Textebene fuer gescannte Dokumente)
+- `POST /viewer/api/ocr/<doc_id>` - OCR als Hintergrund-Job starten (Textebene fuer gescannte Dokumente); antwortet `202` + `{job_id}`, `409` falls fuer das Dokument bereits ein OCR-Job laeuft
+- `GET /viewer/api/jobs/<job_id>` - Status eines Hintergrund-Jobs abfragen (`pending|running|done|error`)
 - `POST /viewer/api/ai/text` - KI-Textbearbeitung/-generierung (nur falls `AI_PROVIDER` konfiguriert)
 
 ### Bibliothekssuche
 - `GET /swb/search` - Bibliothekskatalog-Suche (rendert HTML-Ergebnisseite, `?q=<suchtext>`)
 
 ### Export
-- `POST /export/pdf/<doc_id>` - Annotiertes PDF
-- `POST /export/markdown/<doc_id>` - Markdown-Datei
+- `POST /export/pdf/<doc_id>` - Annotiertes PDF als Hintergrund-Job erzeugen; antwortet `202` + `{job_id}` (Status via `GET /viewer/api/jobs/<job_id>`)
+- `GET /export/download/<job_id>` - Fertiges Export-PDF herunterladen (`409`, solange der Job noch laeuft)
+- `POST /export/markdown/<doc_id>` - Markdown-Datei (synchron)
 - `GET /export/original/<doc_id>` - Original-PDF
 
 ### Admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,24 @@ services:
       # Generate one with: python -c "import secrets; print(secrets.token_hex(32))"
       SECRET_KEY: "${SECRET_KEY:?SECRET_KEY env variable is required}"
       GUNICORN_WORKERS: "${GUNICORN_WORKERS:-2}"
+      # GUNICORN_TIMEOUT defaults to 120s (set in the Dockerfile). OCR and
+      # annotated-PDF export run as background jobs off the request path,
+      # so a long timeout is no longer needed.
+      #
+      # When running behind a TLS-terminating reverse proxy (nginx/Caddy/
+      # Traefik), set PDF_ANNOTATOR_BEHIND_PROXY=1: it enables ProxyFix
+      # (X-Forwarded-For/Proto/Host, 1 hop), Secure session cookies, HSTS
+      # and https URLs — and makes SECRET_KEY mandatory (hard startup
+      # error if missing). Never set it without a trusted proxy in front.
+      # PDF_ANNOTATOR_BEHIND_PROXY: "1"
+      #
+      # Optional hardening: disable self-registration once accounts exist
+      # (the very first user may always register), or require an invite code.
+      # PDF_ANNOTATOR_REGISTRATION: "0"
+      # PDF_ANNOTATOR_INVITE_CODE: "..."
+      #
+      # Optional: shared rate-limit store (default memory:// is per worker).
+      # RATELIMIT_STORAGE_URI: "redis://host:6379"
     healthcheck:
       test: ["CMD", "python", "-c",
              "import urllib.request; urllib.request.urlopen('http://localhost:8000/auth/login')"]

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -13,3 +13,8 @@ SECRET_KEY=change-me-to-a-random-string
 
 # Optional: App-Umgebung (production | development)
 APP_ENV=production
+
+# Optional: Auf "1" setzen, wenn ein TLS-terminierender Reverse-Proxy
+# (z.B. nginx mit X-Forwarded-Proto) vor der App steht. Aktiviert
+# Secure-Cookies, ProxyFix und macht SECRET_KEY zum Pflichtfeld.
+#PDF_ANNOTATOR_BEHIND_PROXY=1

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -18,3 +18,11 @@ APP_ENV=production
 # (z.B. nginx mit X-Forwarded-Proto) vor der App steht. Aktiviert
 # Secure-Cookies, ProxyFix und macht SECRET_KEY zum Pflichtfeld.
 #PDF_ANNOTATOR_BEHIND_PROXY=1
+
+# Optional: Selbstregistrierung deaktivieren (empfohlen, sobald alle
+# Konten angelegt sind). Der allererste Benutzer darf sich immer
+# registrieren, damit eine frische Installation ihren Admin bekommt.
+#PDF_ANNOTATOR_REGISTRATION=0
+
+# Optional: Einladungscode für die Registrierung verlangen.
+#PDF_ANNOTATOR_INVITE_CODE=geheimer-code

--- a/ref/api.md
+++ b/ref/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-All endpoints require login (`@login_required`) unless noted. CSRF token required for all POST/DELETE via `X-CSRFToken` header or form field (except `save_annotation` which is CSRF-exempt).
+All endpoints require login (`@login_required`) unless noted. CSRF token required for all POST/DELETE via `X-CSRFToken` header or form field — including `save_annotation` (no longer CSRF-exempt: the unload-save uses `fetch` with `keepalive: true` + `X-CSRFToken` on `pagehide` instead of `sendBeacon`).
 
 ## Auth — `/auth`
 
@@ -9,8 +9,8 @@ All endpoints require login (`@login_required`) unless noted. CSRF token require
 | GET | `/auth/login` | — | Login page |
 | POST | `/auth/login` | — | Submit credentials; rate-limited 5/min |
 | GET | `/auth/logout` | ✓ | Logout |
-| GET | `/auth/register` | — | Registration page |
-| POST | `/auth/register` | — | Create account (first user becomes admin) |
+| GET | `/auth/register` | — | Registration page; 403 when `PDF_ANNOTATOR_REGISTRATION=0` (unless no user exists yet) |
+| POST | `/auth/register` | — | Create account (first user becomes admin; first user may always register even when self-registration is disabled). With `PDF_ANNOTATOR_INVITE_CODE` set, a matching invite code is required. Forms are Flask-WTF (`forms.py`); messages/status codes unchanged |
 | GET | `/auth/change-password` | ✓ | Change-password page |
 | POST | `/auth/change-password` | ✓ | Verify current password, set new one (min. 8 chars) |
 | POST | `/auth/theme` | ✓ | Save dark/light theme; rate-limited 30/min |
@@ -35,11 +35,12 @@ All endpoints require login (`@login_required`) unless noted. CSRF token require
 | GET | `/viewer/api/page/<doc_id>/<page>` | ✓ | Render page as PNG; rate-limited 60/min |
 | GET | `/viewer/api/page/<doc_id>/<page>/text` | ✓ | Word bounding boxes for the selectable text overlay |
 | GET | `/viewer/api/annotation/<doc_id>/<page>` | ✓ | Get annotation JSON |
-| POST | `/viewer/api/annotation/<doc_id>/<page>` | ✓ | Save annotation (CSRF-exempt, sendBeacon) |
+| POST | `/viewer/api/annotation/<doc_id>/<page>` | ✓ | Save annotation (CSRF-protected like everything else) |
 | POST | `/viewer/api/metadata/<doc_id>` | ✓ | Update document metadata |
 | POST | `/viewer/api/replace/<doc_id>` | ✓ | Replace PDF file (keeps annotations) |
 | POST | `/viewer/api/append/<doc_id>` | ✓ | Append pages from another PDF |
-| POST | `/viewer/api/ocr/<doc_id>` | ✓ | Run OCR (add text layer to scanned docs); rate-limited 3/min; 501 if tesseract missing |
+| POST | `/viewer/api/ocr/<doc_id>` | ✓ | Start OCR as a background job → **202** `{"success": true, "job_id": ...}`; **409** if an OCR job is already pending/running for this document; rate-limited 3/min; 501 if tesseract missing |
+| GET | `/viewer/api/jobs/<job_id>` | ✓ | Poll background job status (OCR, PDF export) → `{"status": "pending"\|"running"\|"done"\|"error", "error": str\|null, "result": {...}}`; 404 unknown job, 403 not owner |
 | DELETE | `/viewer/api/page/<doc_id>/<page>` | ✓ | Delete a page |
 
 ## Export — `/export`
@@ -47,8 +48,9 @@ All endpoints require login (`@login_required`) unless noted. CSRF token require
 | Method | Path | Auth | Description |
 |---|---|---|---|
 | GET | `/export/original/<doc_id>` | ✓ | Download original PDF |
-| POST | `/export/pdf/<doc_id>` | ✓ | Generate and download annotated PDF |
-| POST | `/export/markdown/<doc_id>` | ✓ | Generate and download Markdown notes |
+| POST | `/export/pdf/<doc_id>` | ✓ | Start annotated-PDF export as a background job → **202** `{"success": true, "job_id": ...}`; poll via `GET /viewer/api/jobs/<job_id>`, then fetch the file from `/export/download/<job_id>` |
+| GET | `/export/download/<job_id>` | ✓ | Download the finished export artifact (Desktop-Mode JSON supported); **409** while the job is still pending/running; 404 unknown job or vanished file; 403 not owner |
+| POST | `/export/markdown/<doc_id>` | ✓ | Generate and download Markdown notes (synchronous) |
 
 ## AI Assist — `/viewer/api/ai`
 
@@ -99,6 +101,6 @@ All admin routes require `@admin_required` (is_admin=1 in DB).
 **Ownership violation:** HTTP 403  
 **Not found:** HTTP 404  
 
-## Helper: `_get_doc_or_error(doc_id)`
+## Helper: `get_owned_document(doc_id)` (`routes/_helpers.py`)
 
-Used by all viewer API endpoints. Returns `(doc_info, None)` on success or `(None, error_tuple)` on failure. Validates UUID, checks document exists, checks ownership against `current_user.id`.
+Used by all document-bound endpoints. Validates the UUID, fetches the document, and verifies ownership against `current_user.id` — or aborts with 400 (invalid id), 404 (unknown document), or 403 (owned by someone else). The app-level 400/403/404 handlers render the abort as JSON for API paths (see `wants_json()`) or as the HTML error page for browser requests. `handle_errors(...)` (same module) replaces per-route try/except blocks: HTTPExceptions pass through to the app handlers, anything else is logged and answered as 500.

--- a/ref/architecture.md
+++ b/ref/architecture.md
@@ -14,23 +14,28 @@ Flask-based web application for uploading PDFs, annotating them page-by-page, an
 
 ## Application Factory
 
-`src/pdf_annotator/app.py` — `create_app(config_name)`:
-1. Loads config from `config.py` (development / production / testing)
-2. Sets up Flask-Login, CSRF protection (Flask-WTF), rate limiter (Flask-Limiter)
-3. Initializes DatabaseManager singleton + `init_db()`
-4. Registers all blueprints
-5. Adds `/health` endpoint (no auth, rate-limit exempt)
-6. Attaches security headers via `@after_request`
+`src/pdf_annotator/app.py` — `create_app(config_name, config_overrides=None)`:
+1. Loads config from `config.py` (development / production / testing); `config_overrides` dict is applied on top before anything uses it (mainly for tests)
+2. If `PDF_ANNOTATOR_BEHIND_PROXY=1`: wraps the WSGI app in ProxyFix (`x_for=1, x_proto=1, x_host=1`), sets `PREFERRED_URL_SCHEME=https` and Secure session/remember cookies (HSTS is added in `@after_request`)
+3. Sets up Flask-Login, CSRF protection (Flask-WTF), rate limiter (Flask-Limiter, storage from `RATELIMIT_STORAGE_URI`, default `memory://`)
+4. Creates a `DatabaseManager` instance, stores it in `app.extensions["db"]` (fetched via `get_db()`), calls `init_db()` (runs versioned migrations)
+5. Starts the periodic cleanup thread (`services/cleanup.py`) — skipped in tests and in the Werkzeug reloader parent
+6. Registers all blueprints
+7. Adds `/health` endpoint (no auth, rate-limit exempt)
+8. Attaches security headers via `@after_request`
+9. Registers app-level 400/403/404 handlers that content-negotiate JSON vs the HTML error page (see `routes/_helpers.py: wants_json`)
 
 ## Blueprint Layout
 
-| Blueprint | Prefix | File |
-|---|---|---|
-| `auth_bp` | `/auth` | `routes/auth.py` |
-| `upload_bp` | `/` | `routes/upload.py` |
-| `viewer_bp` | `/viewer` | `routes/viewer.py` |
-| `export_bp` | `/export` | `routes/export.py` |
-| `admin_bp` | `/admin` | `routes/admin.py` |
+| Blueprint | Prefix | File | Notes |
+|---|---|---|---|
+| `auth_bp` | `/auth` | `routes/auth.py` | |
+| `upload_bp` | `/` | `routes/upload.py` | |
+| `viewer_bp` | `/viewer` | `routes/viewer.py` | incl. job-status polling: `GET /viewer/api/jobs/<job_id>` |
+| `export_bp` | `/export` | `routes/export.py` | incl. job-artifact download: `GET /export/download/<job_id>` |
+| `admin_bp` | `/admin` | `routes/admin.py` | |
+| `ai_bp` | `/viewer/api/ai` | `routes/ai.py` | |
+| `swb_bp` | `/swb` | `routes/swb.py` | |
 
 ## Layer Diagram
 
@@ -38,20 +43,27 @@ Flask-based web application for uploading PDFs, annotating them page-by-page, an
 Browser / CLI
     │
 Flask Routes (routes/)
-    ├── auth.py        login, register, logout, theme
+    ├── _helpers.py    shared route helpers (get_owned_document, wants_json, handle_errors)
+    ├── auth.py        login, register, logout, theme (Flask-WTF forms in forms.py)
     ├── upload.py      upload, delete, export-zip, import-zip
-    ├── viewer.py      view, page-image, annotation CRUD, replace, append, delete-page
-    ├── export.py      download original PDF, export annotated PDF, export MD
+    ├── viewer.py      view, page-image, annotation CRUD, replace, append, delete-page,
+    │                  OCR job (202), job-status polling
+    ├── export.py      download original PDF, annotated-PDF export job (202),
+    │                  job-artifact download, export MD (sync)
     └── admin.py       user management (admin-only)
     │
 Services (services/)
-    ├── pdf_processor.py    PyMuPDF rendering, page count, LRU cache
+    ├── pdf_processor.py    PyMuPDF rendering, page count, text layout
+    ├── render_cache.py     shared disk cache for page PNGs + text layouts
+    ├── jobs.py             in-process background jobs (OCR, PDF export)
+    ├── cleanup.py          periodic maintenance thread (exports, jobs, cache prune)
     ├── pdf_generator.py    annotated PDF creation (green Courier footer)
     ├── markdown_exporter.py Markdown note export
     └── data_manager.py     ZIP export/import of all user data
     │
 Models (models/)
-    ├── database.py    SQLite DatabaseManager singleton
+    ├── database.py    SQLite DatabaseManager (one per app, in app.extensions["db"])
+    ├── migrations.py  versioned schema migrations (PRAGMA user_version)
     └── user.py        Flask-Login User model
     │
 Utils (utils/)
@@ -76,8 +88,11 @@ Platform data dirs (production):
 
 ## Key Design Decisions
 
-- **DatabaseManager is a singleton** — `__new__` with thread lock; pass `db_path` only on first instantiation (done in `create_app`). Tests inject `:memory:` via conftest fixture.
-- **CSRF exempt for `save_annotation`** — sendBeacon cannot send custom headers; endpoint validates UUID doc_id instead.
-- **WAL mode** — enabled per-connection in `get_connection()`; persistent in DB header after first set; no-op on `:memory:`.
-- **Render cache** — `_render_page_cached` is an LRU-cached internal function; `render_page_to_image` is the public wrapper that converts None returns to exceptions so cached None values are never stored.
+- **DatabaseManager is NOT a singleton** — one instance per app, created in `create_app()` and stored in `app.extensions["db"]`; routes and services fetch it via `get_db()`. Instances are cheap and thread-safe (every operation opens its own connection). Tests inject `:memory:` via `config_overrides`.
+- **Schema migrations** — versioned via `PRAGMA user_version` with a `MIGRATIONS` list in `models/migrations.py` (baseline + `_m002_jobs`); `init_db()` applies pending migrations.
+- **CSRF everywhere, including `save_annotation`** — the frontend sends `X-CSRFToken` on all mutating requests; the final save on page unload uses `fetch` with `keepalive: true` (which can carry headers) instead of `sendBeacon`, so the former CSRF exemption is gone.
+- **SQLite pragmas** — per-connection in `get_connection()`: `foreign_keys=ON`, `journal_mode=WAL` (persistent in DB header after first set; no-op on `:memory:`), `busy_timeout=10000`, `synchronous=NORMAL`.
+- **Render cache on disk** — page PNGs and text layouts are cached under `RENDER_CACHE_FOLDER` (`services/render_cache.py`), keyed by resolved path + mtime + size, so file mutations auto-invalidate across all workers; pruned LRU to `RENDER_CACHE_MAX_BYTES` by the cleanup thread. Replaces the old per-process `lru_cache`.
+- **Background jobs, no broker** — OCR and annotated-PDF export run on a one-thread `ThreadPoolExecutor` per process (`services/jobs.py`); status lives in the shared SQLite `jobs` table, artifacts on the shared filesystem, so any Gunicorn worker can answer polls.
+- **Cleanup thread** — `services/cleanup.py` runs every 15 min per process (flock dedupes across workers): deletes exports > 1 h, flips orphaned jobs to error, deletes finished jobs > 24 h with artifacts, prunes the render cache.
 - **Atomic operations** — `append_pdf` and `delete_page` use single `get_connection()` transactions to prevent partial-failure inconsistencies.

--- a/ref/database.md
+++ b/ref/database.md
@@ -2,6 +2,8 @@
 
 ## Schema
 
+Versioned via `PRAGMA user_version`: `models/migrations.py` holds a `MIGRATIONS` list (`_m001_baseline` = users/documents/annotations + indices + trigger, `_m002_jobs` = jobs table). `init_db()` calls `apply_migrations(conn)`, which runs the pending entries in order and stamps the version after each step. The baseline is idempotent (IF NOT EXISTS / try-ALTER) so pre-versioning databases converge. New schema changes are added as a new function appended to `MIGRATIONS` — never by editing an existing one.
+
 ### `users`
 ```sql
 CREATE TABLE users (
@@ -53,11 +55,30 @@ CREATE TABLE annotations (
 
 **Trigger:** `update_annotation_timestamp` — sets `updated_at = CURRENT_TIMESTAMP` on any annotation UPDATE.
 
+### `jobs`
+```sql
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,           -- UUID
+    type TEXT NOT NULL,            -- 'ocr' | 'export_pdf'
+    doc_id TEXT NOT NULL,          -- FK → documents.id CASCADE DELETE
+    user_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',  -- pending|running|done|error
+    result_path TEXT,              -- artifact on disk (export PDF)
+    result_json TEXT,              -- remaining runner result as JSON
+    error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    started_at TIMESTAMP,
+    finished_at TIMESTAMP
+)
+```
+
+**Indices:** `idx_jobs_doc_type_status` ON `jobs(doc_id, type, status)`, `idx_jobs_status` ON `jobs(status)`.
+
 ## DatabaseManager
 
-Singleton (`__new__` + threading.Lock). Import: `from pdf_annotator.models.database import DatabaseManager`.
+**No longer a singleton.** One instance per application: `create_app()` builds `DatabaseManager(app.config["DATABASE_PATH"])` and stores it in `app.extensions["db"]`. Fetch it with `get_db()` (requires an application context); background job runners receive the instance explicitly in their closure instead of calling `get_db()`. Instances are cheap and thread-safe — every operation opens its own connection, so a background thread may share an instance with request handlers.
 
-**Instantiation:** `DatabaseManager(db_path)` — only the first call sets `_db_path`. All subsequent calls ignore `db_path`.
+Import: `from pdf_annotator.models.database import DatabaseManager, get_db`.
 
 ### Connection
 
@@ -67,7 +88,7 @@ with db.get_connection() as conn:
 ```
 
 - Opens fresh SQLite connection per call
-- Sets `PRAGMA foreign_keys = ON` and `PRAGMA journal_mode=WAL`
+- Sets `PRAGMA foreign_keys = ON`, `PRAGMA journal_mode=WAL`, `PRAGMA busy_timeout = 10000` (wait instead of "database is locked" when another worker/thread holds the write lock), `PRAGMA synchronous = NORMAL` (safe with WAL, faster than FULL)
 - Commits on exit, rollbacks on `sqlite3.Error`, always closes
 - WAL mode is persistent in the DB file header after first set
 
@@ -112,10 +133,23 @@ with db.get_connection() as conn:
 | `delete_user(user_id)` | `bool` | Cascades to documents + annotations |
 | `count_users()` | `int` | |
 | `count_admins()` | `int` | Used to protect last-admin |
+| `update_password(user_id, password_hash)` | `bool` | |
 | `set_user_theme(user_id, theme)` | `bool` | |
+
+#### Background jobs
+
+| Method | Returns | Notes |
+|---|---|---|
+| `create_job(job_type, doc_id, user_id)` | `str` (job_id UUID) | Inserts a `pending` row |
+| `get_job(job_id)` | `dict \| None` | |
+| `get_active_job(doc_id, job_type)` | `dict \| None` | Latest `pending`/`running` job of that type for the document — used for the duplicate-OCR 409 guard |
+| `mark_job_running(job_id)` | `None` | Sets status + `started_at` |
+| `finish_job(job_id, status, result_path=None, result_json=None, error=None)` | `None` | Terminal status `'done'` or `'error'`, stamps `finished_at` |
+| `mark_stale_jobs_failed(older_than_seconds)` | `int` | Flips orphaned `pending`/`running` jobs to `error` (cleanup thread) |
+| `delete_finished_jobs(older_than_seconds)` | `list[str]` | Deletes old `done`/`error` rows, returns their `result_path`s so the caller can unlink artifacts |
 
 ## Testing Notes
 
 - Tests use `:memory:` DB via `TestingConfig`
-- Fixtures inject db via `app` fixture parameter — never instantiate `DatabaseManager()` directly in tests (singleton issue)
+- Fixtures inject db via the `app` fixture (`create_app` stores the instance in `app.extensions["db"]`); use `get_db()` inside an app context rather than instantiating `DatabaseManager()` ad hoc
 - No nested app contexts in tests

--- a/ref/django-migration-feasibility.md
+++ b/ref/django-migration-feasibility.md
@@ -39,6 +39,15 @@ These are the most serious operational issues, and they are framework-independen
 
 ## Cheaper alternative (recommended)
 
+> **Status:** implemented. All six steps below (plus form classes,
+> ownership/error-handling deduplication, a registration gate, and a
+> cleanup thread) landed on this branch — see the commit history and the
+> updated `ref/architecture.md` / `ref/database.md` / `ref/services.md`.
+> Deviations from the sketch: the render cache is disk-based (mtime/size
+> keyed) instead of Redis, and background jobs use an in-process worker
+> thread plus a SQLite jobs table instead of RQ — both chosen so the
+> desktop build needs no external services.
+
 Incremental hardening within Flask, ordered by impact:
 
 1. **Security config**: set `SESSION_COOKIE_SECURE/HTTPONLY/SAMESITE` in `config.py`, add `werkzeug.middleware.proxy_fix.ProxyFix` for the documented reverse-proxy deployment, and make production fail hard when `SECRET_KEY` is unset instead of generating an ephemeral one.

--- a/ref/django-migration-feasibility.md
+++ b/ref/django-migration-feasibility.md
@@ -1,0 +1,51 @@
+# Django Migration Feasibility
+
+## Question
+
+Would the app be improved by migrating from Flask to Django?
+
+## Verdict
+
+**Possible, but not recommended right now.** Roughly half of the codebase's real pain points map directly onto machinery Django ships out of the box (ORM + migrations, forms, admin, auth flows, security settings). The other half — including the worst operational issues — are framework-independent and would survive a migration untouched. The cost is a near-total rewrite: ~5.6k LOC of application Python, 35 endpoints across 7 blueprints, 11 templates, and 178 tests, plus repackaging the desktop/`.deb` distribution.
+
+Recommendation: stay on Flask and fix the specific gaps incrementally (see [Cheaper alternative](#cheaper-alternative-recommended)). Revisit Django only if the roadmap is a hosted multi-user service, where the admin/auth/permissions machinery pays rent continuously.
+
+## What Django would genuinely improve
+
+| Pain point today | Where | Django equivalent |
+|---|---|---|
+| Raw SQLite behind a `DatabaseManager` singleton; migrations are try/except `ALTER TABLE` loops with no version table or rollback; entities are `sqlite3.Row` dicts (key typos become runtime `KeyError`s); singleton ignores app config after first init, forcing tests to reset `DatabaseManager._instance` manually | `models/database.py` (839 lines), `tests/conftest.py` | ORM models + `makemigrations`/`migrate`; Postgres becomes a settings change |
+| Hand-rolled validation layer plus ~85 lines of procedural form checks in registration; Flask-WTF is installed but used only for CSRF | `utils/validators.py` (337 lines), `routes/auth.py:91-176` | Forms / ModelForms with declarative validation |
+| Custom admin panel, including two near-identical 40-line toggle functions (the pyscn clone group) | `routes/admin.py` + `templates/admin/index.html` (320 lines) | `django.contrib.admin`, nearly free |
+| No password reset, no email verification, no account lockout, password policy is only `len >= 8` | `routes/auth.py` | `django.contrib.auth` password-reset flows and pluggable password validators |
+| No `SESSION_COOKIE_SECURE/HTTPONLY/SAMESITE`, no `ProxyFix` despite the documented TLS-reverse-proxy deployment, ephemeral fallback `SECRET_KEY` in production (restart or a second Gunicorn worker breaks sessions) | `config.py` | Conventional settings + `manage.py check --deploy` catches these |
+| Repeated "validate doc_id → fetch → check ownership" blocks and ~15 near-identical try/except-with-error-message wrappers per route | `routes/viewer.py`, `routes/upload.py`, `routes/export.py` | `get_object_or_404`, queryset filtering by owner, exception middleware |
+
+## What Django would NOT fix
+
+These are the most serious operational issues, and they are framework-independent:
+
+- **Synchronous OCR and PDF export inside requests.** `OCR_TIMEOUT_SECONDS = 600` is why the Gunicorn timeout is 600 s; one OCR request blocks a worker for up to 10 minutes. The fix is a task queue (Celery/RQ or Django 6's tasks framework) — plumbing work on either framework.
+- **SQLite under multiple Gunicorn workers** hits `database is locked` under concurrent writes. The fix is Postgres, available to Flask via SQLAlchemy just as well.
+- **Per-process `lru_cache` for rendered page images** (`services/pdf_processor.py`): `clear_render_cache()` only clears the calling worker's cache, so other workers can serve stale pages after a PDF replace or OCR — the reason the cache-buster workaround exists. The fix is a shared cache (Redis); Django's cache framework helps slightly but doesn't remove the work.
+- **Cleanup piggybacked on requests** (`cleanup_old_exports()` in `routes/export.py`) needs a scheduler either way.
+- The ~1.9k LOC vanilla-JS frontend, 2.3k lines of CSS, and the PDF/OCR/AI service layer (`services/`) are framework-neutral and would port as-is — i.e., they gain nothing.
+
+## Migration cost
+
+- Rewrite all 35 endpoints, the Flask-Login integration, and most of the 178 tests; convert or adapt 11 Jinja2 templates (Django can run Jinja2, but URL reversing, CSRF tags, and auth context differ).
+- The desktop distribution (flaskwebgui + bundled-venv `.deb` + systemd unit + platform data dirs in `desktop.py`/`packaging/`) is built around an embedded single-process Flask app. flaskwebgui supports Django, but `manage.py`-style startup, `STATIC_ROOT`/`collectstatic`, and the settings module layout all require rework.
+- Realistic effort: several weeks with meaningful regression risk, for little user-visible gain.
+
+## Cheaper alternative (recommended)
+
+Incremental hardening within Flask, ordered by impact:
+
+1. **Security config**: set `SESSION_COOKIE_SECURE/HTTPONLY/SAMESITE` in `config.py`, add `werkzeug.middleware.proxy_fix.ProxyFix` for the documented reverse-proxy deployment, and make production fail hard when `SECRET_KEY` is unset instead of generating an ephemeral one.
+2. **Background jobs**: move OCR and 300-DPI export into a task queue (RQ is the lightest fit alongside a Redis cache); drop the 600 s Gunicorn timeout.
+3. **Database**: adopt Alembic for versioned migrations (keeping raw SQLite or moving to SQLAlchemy Core), set `busy_timeout`, and offer a Postgres option for multi-worker deployments. Refactor `DatabaseManager` to read config per-app instead of process-global state.
+4. **Forms**: use Flask-WTF form classes (already a dependency) for register/login/metadata, retiring most of `utils/validators.py`.
+5. **Shared render cache**: replace the per-process `lru_cache` with Redis (or accept single-worker deployments and document it).
+6. **Deduplicate**: extend the `_get_doc_or_error()` pattern from `routes/viewer.py` across `upload.py`/`export.py`, and collapse the per-route try/except blocks into Flask error handlers.
+
+Each step is independently shippable and testable against the existing suite, whereas a Django migration is all-or-nothing.

--- a/ref/services.md
+++ b/ref/services.md
@@ -16,16 +16,51 @@ Returns number of pages. Used by `replace_pdf` (append_pdf uses `doc_info["page_
 Returns `(width, height)` in points for the given page (1-indexed).
 
 **`render_page_to_image(file_path: str, page_num: int, dpi: int = 300) -> bytes | None`**  
-Public API. Calls `_render_page_cached` internally; catches exceptions and returns `None` instead of propagating (so `None` is never stored in cache).
+Public API. Serves from the shared disk cache (`render_cache.get_or_render_page`) when an app context provides `RENDER_CACHE_FOLDER`; renders via the internal `_render_page` on miss. Catches exceptions and returns `None` instead of propagating (errors are never cached).
 
-**`_render_page_cached(file_path: str, page_num: int, dpi: int) -> bytes`** *(internal, LRU-cached)*  
+**`get_page_text_layout(file_path: str, page_num: int) -> dict`**  
+Word-level text with bounding boxes for the selectable text overlay. Served from the shared disk cache (`render_cache.get_or_load_layout`); extraction (`_extract_text_layout`) raises on invalid pages so errors are never cached.
+
+**`_render_page(file_path: str, page_num: int, dpi: int) -> bytes`** *(internal)*  
 Raises exception on failure — ensures only successful renders are cached.
 
-**`clear_render_cache() -> None`**  
-Clears LRU cache. Called after PDF replace/append/delete-page operations.
+Note: the old per-process `functools.lru_cache` and its helpers (`clear_render_cache`, `clear_text_layout_cache`, `get_cache_info`) are gone — the disk cache is keyed by file identity (path + mtime + size), so PDF mutations (replace/append/OCR/delete-page) invalidate automatically in every worker; no explicit cache clearing exists or is needed.
 
-**`get_cache_info() -> dict`**  
-Returns `functools.lru_cache` stats for `_render_page_cached`.
+---
+
+## render_cache.py
+
+Disk-based cache for rendered page PNGs and text layouts, shared by all Gunicorn workers. Lives under `RENDER_CACHE_FOLDER` (prod: `<data_dir>/cache`); size budget `RENDER_CACHE_MAX_BYTES` (default 512 MB).
+
+Entries are keyed by the PDF's content identity — sha1 of `resolved path | mtime_ns | size` — so every file mutation changes the key and stale entries are simply never hit again (no cross-process invalidation signal). Reads refresh the entry's mtime; `prune()` (called by the cleanup thread) evicts least-recently-used entries until the cache fits the budget, removes leftover temp files, and drops empty directories. Writes are atomic (unique temp name + `os.replace`), so concurrent workers may render the same page twice (harmless) but never serve a torn file.
+
+**`get_or_render_page(cache_dir, file_path, page_num, dpi, render) -> bytes`**  
+**`get_or_load_layout(cache_dir, file_path, page_num, extract) -> dict`**  
+**`prune(cache_dir, max_bytes) -> int`** — returns bytes freed.
+
+---
+
+## jobs.py
+
+In-process background jobs for long-running work (OCR, annotated-PDF export). One worker thread per process (`ThreadPoolExecutor(max_workers=1)`) runs jobs off the request path; status lives in the shared SQLite `jobs` table and artifacts on the shared filesystem, so with multiple Gunicorn workers any worker can answer a poll for a job another worker is running. No broker or external queue; the same code path serves the single-process desktop app.
+
+**`submit_job(db, job_type, doc_id, user_id, runner) -> str`**  
+Inserts a `pending` job row and executes `runner` on the background thread. Returns the job_id (polled via `GET /viewer/api/jobs/<job_id>`). The runner must not touch `current_app`/`request`/`current_user` — everything it needs (db instance, file paths, config values) is captured in the closure at submit time. The runner returns a result dict; `"result_path"` is persisted to `jobs.result_path`, the rest to `result_json`. Exceptions mark the job `error` with the message.
+
+Constants: `JOB_STALE_SECONDS = 900` (pending/running older than this is considered orphaned and flipped to error by cleanup; exceeds the OCR timeout with margin), `FINISHED_JOB_RETENTION_SECONDS = 24 * 3600` (terminal rows + artifacts removed after this age).
+
+---
+
+## cleanup.py
+
+Periodic maintenance, moved off the request path. `start_cleanup_thread(app)` (called from `create_app`, skipped in tests) starts one daemon thread per process that wakes every 15 minutes (`CLEANUP_INTERVAL_SECONDS`, plus jitter; first round ~10 s after startup so jobs orphaned by a crash/deploy are recovered promptly) and:
+
+- deletes export artifacts older than 1 h (`EXPORT_MAX_AGE_SECONDS`)
+- flips orphaned background jobs to `error` (`mark_stale_jobs_failed`)
+- deletes finished job rows older than 24 h and unlinks their artifacts
+- prunes the render cache to `RENDER_CACHE_MAX_BYTES`
+
+Every task is idempotent; with multiple Gunicorn workers a non-blocking `flock` on `<data_dir>/cleanup.lock` merely skips redundant rounds (on platforms without `fcntl` the lock is skipped entirely).
 
 ---
 
@@ -102,7 +137,7 @@ Route: `POST /viewer/api/ai/text` (`routes/ai.py`) — stateless, not tied to a 
 OCR for scanned documents (in-app "OCR" button in the viewer).
 
 **`ocr_pdf(file_path, language="deu+eng") -> None`**  
-Runs `ocrmypdf --skip-text` in a subprocess (its Python API isn't thread-safe in a web worker) to add a searchable text layer in place; temp file + replace, 600s timeout. Raises `OCRError` on failure. **`ocr_available()`** checks for the tesseract binary — exposed to templates as `ocr_available` (context processor) and to JS as `window.__ocrAvailable`; the route returns 501 when missing. Docker image installs `tesseract-ocr` + `deu`/`eng` language packs + ghostscript; on macOS use `brew install tesseract ocrmypdf`.
+Runs `ocrmypdf --skip-text` in a subprocess (its Python API isn't thread-safe in a web worker) to add a searchable text layer in place; temp file + replace, 600s subprocess timeout. Raises `OCRError` on failure. Invoked as a **background job** (see `jobs.py`): `POST /viewer/api/ocr/<doc_id>` returns 202 + `job_id` (409 if an OCR job is already active for the document), the frontend polls `GET /viewer/api/jobs/<job_id>` — the request no longer blocks a Gunicorn worker for the duration of the OCR run. **`ocr_available()`** checks for the tesseract binary — exposed to templates as `ocr_available` (context processor) and to JS as `window.__ocrAvailable`; the route returns 501 when missing. Docker image installs `tesseract-ocr` + `deu`/`eng` language packs + ghostscript; on macOS use `brew install tesseract ocrmypdf`.
 
 Note: pages with a `/Rotate` flag (typical for scans) are handled in `pdf_processor.get_page_text_layout()` — word boxes are mapped through `page.rotation_matrix` into rendered space, since `get_text("words")` reports unrotated coordinates while `get_pixmap()` renders rotated.
 

--- a/src/pdf_annotator/app.py
+++ b/src/pdf_annotator/app.py
@@ -52,6 +52,22 @@ def create_app(config_name: str | None = None) -> Flask:
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
 
+    # Reverse-proxy deployments (PDF_ANNOTATOR_BEHIND_PROXY=1): trust the
+    # proxy's X-Forwarded-* headers and switch to https semantics. Never
+    # enabled for the desktop app or a directly exposed dev server, where
+    # forwarding headers would be attacker-controlled.
+    behind_proxy = os.environ.get("PDF_ANNOTATOR_BEHIND_PROXY") == "1"
+    app.config["BEHIND_PROXY"] = behind_proxy
+    if behind_proxy:
+        from werkzeug.middleware.proxy_fix import ProxyFix
+
+        app.wsgi_app = ProxyFix(  # type: ignore[method-assign]
+            app.wsgi_app, x_for=1, x_proto=1, x_host=1
+        )
+        app.config["PREFERRED_URL_SCHEME"] = "https"
+        app.config["SESSION_COOKIE_SECURE"] = True
+        app.config["REMEMBER_COOKIE_SECURE"] = True
+
     # Setup logging
     logger = setup_logger(
         name="pdf_annotator",
@@ -161,6 +177,10 @@ def create_app(config_name: str | None = None) -> Flask:
             "img-src 'self' data: blob:; "
             "font-src 'self' data:"
         )
+        if app.config.get("BEHIND_PROXY"):
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=31536000; includeSubDomains"
+            )
         return response
 
     # Error handlers

--- a/src/pdf_annotator/app.py
+++ b/src/pdf_annotator/app.py
@@ -128,6 +128,18 @@ def create_app(
     db.init_db()
     logger.info("Database initialized")
 
+    # Periodic maintenance (export/job/cache cleanup) off the request path.
+    # Skipped in tests, and in the Werkzeug reloader parent (the reloaded
+    # child, marked by WERKZEUG_RUN_MAIN, starts its own thread).
+    start_cleanup = not app.config.get("TESTING")
+    if app.debug and os.environ.get("WERKZEUG_RUN_MAIN") != "true":
+        start_cleanup = False
+    if start_cleanup:
+        from pdf_annotator.services.cleanup import start_cleanup_thread
+
+        start_cleanup_thread(app)
+        logger.info("Cleanup thread started")
+
     # Register blueprints
     app.register_blueprint(auth_bp)
     app.register_blueprint(upload_bp)

--- a/src/pdf_annotator/app.py
+++ b/src/pdf_annotator/app.py
@@ -102,12 +102,15 @@ def create_app(config_name: str | None = None) -> Flask:
     # Initialize CSRF protection
     CSRFProtect(app)
 
-    # Initialize rate limiter
+    # Initialize rate limiter. The default memory:// storage is
+    # per-process: with N Gunicorn workers, effective limits are up to
+    # N x the configured value and reset on worker restart. Operators
+    # with a shared store can point RATELIMIT_STORAGE_URI at it.
     limiter = Limiter(
         get_remote_address,
         app=app,
         default_limits=["200 per minute"],
-        storage_uri="memory://",
+        storage_uri=app.config.get("RATELIMIT_STORAGE_URI", "memory://"),
     )
 
     # Initialize database

--- a/src/pdf_annotator/app.py
+++ b/src/pdf_annotator/app.py
@@ -182,33 +182,61 @@ def create_app(config_name: str | None = None) -> Flask:
             )
         return response
 
-    # Error handlers
+    # Error handlers. API requests (see wants_json) get JSON carrying the
+    # abort's description; browser page requests get the HTML error page
+    # with the same fixed German texts as before.
+    def _client_error_response(
+        e: Any, status: int, error_title: str, html_message: str, json_default: str
+    ) -> tuple:
+        from flask import render_template
+        from werkzeug.exceptions import HTTPException
+
+        from pdf_annotator.routes._helpers import wants_json
+
+        description = None
+        if isinstance(e, HTTPException) and e.description != type(e).description:
+            description = e.description
+
+        if wants_json():
+            return jsonify({"error": description or json_default}), status
+        return (
+            render_template(
+                "error.html", error_title=error_title, error_message=html_message
+            ),
+            status,
+        )
+
+    @app.errorhandler(400)
+    def bad_request(e: Any) -> tuple:
+        """Handle 400 errors."""
+        return _client_error_response(
+            e,
+            400,
+            error_title="Ungültige Anfrage",
+            html_message="Die Anfrage war ungültig.",
+            json_default="Ungültige Anfrage",
+        )
+
     @app.errorhandler(404)
     def not_found(e: Any) -> tuple:
         """Handle 404 errors."""
-        from flask import render_template
-
-        return (
-            render_template(
-                "error.html",
-                error_title="Seite nicht gefunden",
-                error_message="Die angeforderte Seite wurde nicht gefunden.",
-            ),
+        return _client_error_response(
+            e,
             404,
+            error_title="Seite nicht gefunden",
+            html_message="Die angeforderte Seite wurde nicht gefunden.",
+            json_default="Nicht gefunden",
         )
 
     @app.errorhandler(403)
     def forbidden(e: Any) -> tuple:
         """Handle 403 errors."""
-        from flask import render_template
-
-        return (
-            render_template(
-                "error.html",
-                error_title="Nicht berechtigt",
-                error_message="Sie haben keine Berechtigung für diese Seite.",
-            ),
+        return _client_error_response(
+            e,
             403,
+            error_title="Nicht berechtigt",
+            html_message="Sie haben keine Berechtigung für diese Seite.",
+            json_default="Nicht berechtigt",
         )
 
     @app.errorhandler(500)

--- a/src/pdf_annotator/app.py
+++ b/src/pdf_annotator/app.py
@@ -14,7 +14,7 @@ from flask_login import LoginManager
 from flask_wtf.csrf import CSRFProtect
 
 from pdf_annotator.config import config
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import DatabaseManager, get_db
 from pdf_annotator.models.user import User
 from pdf_annotator.routes.admin import admin_bp
 from pdf_annotator.routes.ai import ai_bp
@@ -26,13 +26,19 @@ from pdf_annotator.routes.viewer import viewer_bp
 from pdf_annotator.utils.logger import setup_logger
 
 
-def create_app(config_name: str | None = None) -> Flask:
+def create_app(
+    config_name: str | None = None,
+    config_overrides: dict[str, Any] | None = None,
+) -> Flask:
     """
     Application factory for creating Flask app.
 
     Args:
         config_name: Configuration name (development, production, testing)
                     If None, uses FLASK_ENV environment variable or defaults to 'development'
+        config_overrides: Config values applied on top of the named config
+                    before any of them are used (paths, feature flags, ...).
+                    Mainly for tests.
 
     Returns:
         Flask: Configured Flask application instance
@@ -50,6 +56,8 @@ def create_app(config_name: str | None = None) -> Flask:
 
     # Load configuration
     app.config.from_object(config[config_name])
+    if config_overrides:
+        app.config.update(config_overrides)
     config[config_name].init_app(app)
 
     # Reverse-proxy deployments (PDF_ANNOTATOR_BEHIND_PROXY=1): trust the
@@ -86,7 +94,7 @@ def create_app(config_name: str | None = None) -> Flask:
     @login_manager.user_loader
     def load_user(user_id: str) -> User | None:
         """Load user from database by ID."""
-        db = DatabaseManager()
+        db = get_db()
         data = db.get_user_by_id(user_id)
         if data:
             return User(
@@ -113,8 +121,10 @@ def create_app(config_name: str | None = None) -> Flask:
         storage_uri=app.config.get("RATELIMIT_STORAGE_URI", "memory://"),
     )
 
-    # Initialize database
+    # Initialize database; the instance lives on app.extensions so routes
+    # and services reach it via get_db() with the app's configured path.
     db = DatabaseManager(app.config["DATABASE_PATH"])
+    app.extensions["db"] = db
     db.init_db()
     logger.info("Database initialized")
 
@@ -133,7 +143,7 @@ def create_app(config_name: str | None = None) -> Flask:
     def health_check() -> Any:
         db_ok = True
         try:
-            with DatabaseManager().get_connection() as conn:
+            with get_db().get_connection() as conn:
                 conn.execute("SELECT 1")
         except Exception:
             db_ok = False

--- a/src/pdf_annotator/app.py
+++ b/src/pdf_annotator/app.py
@@ -100,11 +100,7 @@ def create_app(config_name: str | None = None) -> Flask:
         return None
 
     # Initialize CSRF protection
-    csrf = CSRFProtect(app)
-
-    # Exempt save_annotation from CSRF for sendBeacon support
-    # (sendBeacon cannot send custom headers; endpoint validates doc_id UUID)
-    csrf.exempt("pdf_annotator.routes.viewer.save_annotation")
+    CSRFProtect(app)
 
     # Initialize rate limiter
     limiter = Limiter(

--- a/src/pdf_annotator/config.py
+++ b/src/pdf_annotator/config.py
@@ -160,6 +160,12 @@ class Config:
     # Database settings
     DATABASE_PATH: Path | str = BASE_DIR / "data" / "annotations.db"
 
+    # Rate limiter storage. memory:// is per-process (limits multiply by
+    # the number of Gunicorn workers and reset on restart); deployments
+    # with a shared store can point this at e.g. redis://host:6379
+    # (requires installing the matching `limits` backend extra).
+    RATELIMIT_STORAGE_URI = os.environ.get("RATELIMIT_STORAGE_URI", "memory://")
+
     # Desktop-Mode: export routes write directly to disk instead of streaming
     # an HTTP download. Needed for WebView-based desktop shells (e.g. Toga)
     # that cannot handle Content-Disposition: attachment responses. Must

--- a/src/pdf_annotator/config.py
+++ b/src/pdf_annotator/config.py
@@ -148,6 +148,13 @@ class Config:
     EXPORT_FOLDER = BASE_DIR / "data" / "exports"
     ALLOWED_EXTENSIONS = {"pdf"}
 
+    # Disk cache for rendered page images and text layouts, shared by all
+    # workers (see services/render_cache.py). Entries are keyed by file
+    # mtime/size, so no manual invalidation is needed; the cleanup thread
+    # prunes it to RENDER_CACHE_MAX_BYTES.
+    RENDER_CACHE_FOLDER = BASE_DIR / "data" / "cache"
+    RENDER_CACHE_MAX_BYTES = 512 * 1024 * 1024  # 512 MB
+
     # Input validation limits
     MAX_FILENAME_LENGTH = 255
     MAX_NAME_LENGTH = 100  # For first/last name
@@ -213,6 +220,7 @@ class Config:
         """
         Config.UPLOAD_FOLDER.mkdir(parents=True, exist_ok=True)
         Config.EXPORT_FOLDER.mkdir(parents=True, exist_ok=True)
+        Config.RENDER_CACHE_FOLDER.mkdir(parents=True, exist_ok=True)
         if isinstance(Config.DATABASE_PATH, Path):
             Config.DATABASE_PATH.parent.mkdir(parents=True, exist_ok=True)
 
@@ -241,6 +249,7 @@ class ProductionConfig(Config):
     DATA_DIR = get_data_dir()
     UPLOAD_FOLDER = DATA_DIR / "uploads"
     EXPORT_FOLDER = DATA_DIR / "exports"
+    RENDER_CACHE_FOLDER = DATA_DIR / "cache"
     DATABASE_PATH = DATA_DIR / "annotations.db"
     LOG_FILE = DATA_DIR / "app.log"
 
@@ -281,6 +290,7 @@ class ProductionConfig(Config):
         # Use ProductionConfig paths, not base Config
         app.config["UPLOAD_FOLDER"].mkdir(parents=True, exist_ok=True)
         app.config["EXPORT_FOLDER"].mkdir(parents=True, exist_ok=True)
+        app.config["RENDER_CACHE_FOLDER"].mkdir(parents=True, exist_ok=True)
         app.config["DATABASE_PATH"].parent.mkdir(parents=True, exist_ok=True)
 
 

--- a/src/pdf_annotator/config.py
+++ b/src/pdf_annotator/config.py
@@ -166,6 +166,14 @@ class Config:
     # (requires installing the matching `limits` backend extra).
     RATELIMIT_STORAGE_URI = os.environ.get("RATELIMIT_STORAGE_URI", "memory://")
 
+    # User self-registration. Open by default: the desktop app and the
+    # first-run server setup depend on it. Server operators should set
+    # PDF_ANNOTATOR_REGISTRATION=0 (and/or require an invite code) once
+    # the needed accounts exist. Registration of the very first user is
+    # always allowed so a locked-down fresh install can create its admin.
+    REGISTRATION_ENABLED = os.environ.get("PDF_ANNOTATOR_REGISTRATION", "1") != "0"
+    REGISTRATION_INVITE_CODE = os.environ.get("PDF_ANNOTATOR_INVITE_CODE") or None
+
     # Desktop-Mode: export routes write directly to disk instead of streaming
     # an HTTP download. Needed for WebView-based desktop shells (e.g. Toga)
     # that cannot handle Content-Disposition: attachment responses. Must

--- a/src/pdf_annotator/config.py
+++ b/src/pdf_annotator/config.py
@@ -59,6 +59,36 @@ def get_data_dir() -> Path:
 load_dotenv(get_data_dir() / ".env")
 
 
+def _load_or_create_secret_key(data_dir: Path) -> str:
+    """
+    Load the persistent SECRET_KEY from the data directory, creating it on
+    first use.
+
+    Keeping the key in a file (instead of generating a fresh one per process)
+    keeps sessions valid across restarts and, on servers, consistent across
+    Gunicorn workers that share the data directory.
+    """
+    key_file = data_dir / "secret_key"
+    try:
+        existing = key_file.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+    except FileNotFoundError:
+        pass
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+    new_key = secrets.token_hex(32)
+    try:
+        # O_EXCL so concurrent first-boot workers agree on a single key:
+        # exactly one writer wins, everyone else reads the winner's file.
+        fd = os.open(key_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return key_file.read_text(encoding="utf-8").strip() or new_key
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(new_key)
+    return new_key
+
+
 def get_downloads_dir() -> Path:
     """
     Get platform-specific Downloads directory, used by DESKTOP_MODE exports.
@@ -101,6 +131,16 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY") or secrets.token_hex(32)
     DEBUG = False
     TESTING = False
+
+    # Session cookie hardening. SECURE stays off here because the desktop
+    # app and dev server run over plain http on 127.0.0.1; it is enabled
+    # at app creation when PDF_ANNOTATOR_BEHIND_PROXY=1 (TLS-terminating
+    # reverse proxy in front).
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = "Lax"
+    SESSION_COOKIE_SECURE = False
+    REMEMBER_COOKIE_HTTPONLY = True
+    REMEMBER_COOKIE_SECURE = False
 
     # Upload settings
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50 MB max file size
@@ -182,7 +222,6 @@ class ProductionConfig(Config):
     """
 
     DEBUG = False
-    SECRET_KEY = os.environ.get("SECRET_KEY") or secrets.token_hex(32)
 
     # Use platform-specific data directory
     DATA_DIR = get_data_dir()
@@ -200,10 +239,17 @@ class ProductionConfig(Config):
             app: Flask application instance
         """
         if not os.environ.get("SECRET_KEY"):
-            warnings.warn(
-                "SECRET_KEY ist nicht gesetzt! Sessions werden nach Neustart ungültig. "
-                "Setzen Sie die Umgebungsvariable SECRET_KEY für Production.",
-                stacklevel=2,
+            if os.environ.get("PDF_ANNOTATOR_BEHIND_PROXY") == "1":
+                raise RuntimeError(
+                    "SECRET_KEY ist nicht gesetzt! Für Server-Deployments hinter "
+                    "einem Reverse-Proxy (PDF_ANNOTATOR_BEHIND_PROXY=1) muss die "
+                    "Umgebungsvariable SECRET_KEY gesetzt sein."
+                )
+            # Desktop / standalone server: persist a generated key in the
+            # data directory so sessions survive restarts and all workers
+            # sharing the directory sign with the same key.
+            app.config["SECRET_KEY"] = _load_or_create_secret_key(
+                ProductionConfig.DATA_DIR
             )
         ai_provider = app.config.get("AI_PROVIDER")
         if ai_provider == "anthropic" and not app.config.get("ANTHROPIC_API_KEY"):

--- a/src/pdf_annotator/forms.py
+++ b/src/pdf_annotator/forms.py
@@ -1,0 +1,106 @@
+"""
+Form definitions for the authentication views.
+
+Validation rules and every user-facing message mirror the previous
+hand-rolled checks in routes/auth.py exactly; only the mechanics moved
+into Flask-WTF form classes.
+"""
+
+from flask_wtf import FlaskForm
+from wtforms import PasswordField, StringField
+from wtforms.validators import DataRequired, EqualTo, Length, ValidationError
+
+
+def _strip(value: str | None) -> str | None:
+    return value.strip() if isinstance(value, str) else value
+
+
+def _first_error(form: FlaskForm) -> str | None:
+    """
+    Return the message to show for a failed validation.
+
+    Missing-field (DataRequired) errors win over format errors regardless
+    of field order, mirroring the previous checks which tested presence of
+    all fields first.
+    """
+    for field in form:
+        if field.errors and not field.data:
+            return str(field.errors[0])
+    for field in form:
+        if field.errors:
+            return str(field.errors[0])
+    return None
+
+
+class LoginForm(FlaskForm):
+    username = StringField(
+        "Benutzername",
+        filters=[_strip],
+        validators=[DataRequired(message="Benutzername und Passwort erforderlich.")],
+    )
+    password = PasswordField(
+        "Passwort",
+        validators=[DataRequired(message="Benutzername und Passwort erforderlich.")],
+    )
+
+
+class RegisterForm(FlaskForm):
+    username = StringField(
+        "Benutzername",
+        filters=[_strip],
+        validators=[
+            DataRequired(message="Alle Felder erforderlich."),
+            Length(
+                min=3,
+                max=50,
+                message="Benutzername muss zwischen 3 und 50 Zeichen lang sein.",
+            ),
+        ],
+    )
+    email = StringField(
+        "E-Mail",
+        filters=[_strip],
+        validators=[DataRequired(message="Alle Felder erforderlich.")],
+    )
+    password = PasswordField(
+        "Passwort",
+        validators=[
+            DataRequired(message="Alle Felder erforderlich."),
+            Length(min=8, message="Passwort muss mindestens 8 Zeichen lang sein."),
+        ],
+    )
+    password_confirm = PasswordField(
+        "Passwort bestätigen",
+        validators=[
+            EqualTo("password", message="Passwörter stimmen nicht überein."),
+        ],
+    )
+
+    def validate_email(self, field: StringField) -> None:
+        # Same basic check as before; deliberately permissive so no
+        # previously accepted address is rejected now.
+        email = field.data or ""
+        if "@" not in email or "." not in email.split("@")[1]:
+            raise ValidationError("Ungültige E-Mail-Adresse.")
+
+
+class ChangePasswordForm(FlaskForm):
+    current_password = PasswordField(
+        "Aktuelles Passwort",
+        validators=[DataRequired(message="Aktuelles Passwort ist falsch.")],
+    )
+    new_password = PasswordField(
+        "Neues Passwort",
+        validators=[
+            DataRequired(message="Neues Passwort muss mindestens 8 Zeichen lang sein."),
+            Length(
+                min=8, message="Neues Passwort muss mindestens 8 Zeichen lang sein."
+            ),
+        ],
+    )
+    new_password_confirm = PasswordField(
+        "Neues Passwort bestätigen",
+        validators=[
+            EqualTo("new_password", message="Neue Passwörter stimmen nicht überein."),
+        ],
+    )

--- a/src/pdf_annotator/forms.py
+++ b/src/pdf_annotator/forms.py
@@ -75,6 +75,8 @@ class RegisterForm(FlaskForm):
             EqualTo("password", message="Passwörter stimmen nicht überein."),
         ],
     )
+    # Only checked in the route when REGISTRATION_INVITE_CODE is configured.
+    invite_code = StringField("Einladungscode", filters=[_strip])
 
     def validate_email(self, field: StringField) -> None:
         # Same basic check as before; deliberately permissive so no

--- a/src/pdf_annotator/models/database.py
+++ b/src/pdf_annotator/models/database.py
@@ -717,6 +717,117 @@ class DatabaseManager:
         except sqlite3.Error:
             return False
 
+    # --- Background jobs -------------------------------------------------
+
+    def create_job(self, job_type: str, doc_id: str, user_id: str) -> str:
+        """Insert a pending background job row and return its id."""
+        job_id = str(uuid4())
+        with self.get_connection() as conn:
+            conn.execute(
+                "INSERT INTO jobs (id, type, doc_id, user_id) VALUES (?, ?, ?, ?)",
+                (job_id, job_type, doc_id, user_id),
+            )
+        return job_id
+
+    def get_job(self, job_id: str) -> dict[str, Any] | None:
+        """Fetch a job row by id."""
+        with self.get_connection() as conn:
+            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+            return dict(row) if row else None
+
+    def get_active_job(self, doc_id: str, job_type: str) -> dict[str, Any] | None:
+        """Fetch a pending/running job of the given type for a document."""
+        with self.get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT * FROM jobs
+                WHERE doc_id = ? AND type = ? AND status IN ('pending', 'running')
+                ORDER BY created_at DESC LIMIT 1
+                """,
+                (doc_id, job_type),
+            ).fetchone()
+            return dict(row) if row else None
+
+    def mark_job_running(self, job_id: str) -> None:
+        """Transition a job to running and stamp started_at."""
+        with self.get_connection() as conn:
+            conn.execute(
+                """
+                UPDATE jobs
+                SET status = 'running', started_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (job_id,),
+            )
+
+    def finish_job(
+        self,
+        job_id: str,
+        status: str,
+        result_path: str | None = None,
+        result_json: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Transition a job to a terminal status ('done' or 'error')."""
+        with self.get_connection() as conn:
+            conn.execute(
+                """
+                UPDATE jobs
+                SET status = ?, result_path = ?, result_json = ?, error = ?,
+                    finished_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (status, result_path, result_json, error, job_id),
+            )
+
+    def mark_stale_jobs_failed(self, older_than_seconds: int) -> int:
+        """
+        Flip pending/running jobs older than the cutoff to 'error'.
+
+        Recovers rows orphaned by a killed worker so clients stop polling.
+        Returns the number of jobs flipped.
+        """
+        with self.get_connection() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE jobs
+                SET status = 'error',
+                    error = 'Vorgang abgebrochen (Serverneustart oder Timeout)',
+                    finished_at = CURRENT_TIMESTAMP
+                WHERE status IN ('pending', 'running')
+                  AND created_at < datetime('now', ?)
+                """,
+                (f"-{int(older_than_seconds)} seconds",),
+            )
+            return int(cursor.rowcount)
+
+    def delete_finished_jobs(self, older_than_seconds: int) -> list[str]:
+        """
+        Delete done/error jobs older than the cutoff.
+
+        Returns the result_path values of the deleted rows so the caller
+        can remove the artifacts from disk.
+        """
+        with self.get_connection() as conn:
+            cutoff = f"-{int(older_than_seconds)} seconds"
+            rows = conn.execute(
+                """
+                SELECT result_path FROM jobs
+                WHERE status IN ('done', 'error')
+                  AND finished_at < datetime('now', ?)
+                """,
+                (cutoff,),
+            ).fetchall()
+            conn.execute(
+                """
+                DELETE FROM jobs
+                WHERE status IN ('done', 'error')
+                  AND finished_at < datetime('now', ?)
+                """,
+                (cutoff,),
+            )
+            return [row["result_path"] for row in rows if row["result_path"]]
+
 
 def get_db() -> DatabaseManager:
     """

--- a/src/pdf_annotator/models/database.py
+++ b/src/pdf_annotator/models/database.py
@@ -6,46 +6,35 @@ for documents and annotations.
 """
 
 import sqlite3
-import threading
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from uuid import uuid4
+
+from flask import current_app
+
+from pdf_annotator.models.migrations import apply_migrations
 
 
 class DatabaseManager:
     """
-    Singleton database manager for SQLite operations.
+    SQLite database access for documents, annotations, and users.
 
-    Handles connection management, schema creation, and all database operations
-    for documents and annotations.
+    One instance per application, created in create_app() and stored in
+    app.extensions["db"] (fetch it with get_db()). Instances are cheap
+    and thread-safe: every operation opens its own connection, so a
+    background thread may share an instance with request handlers.
     """
 
-    _instance: Optional["DatabaseManager"] = None
-    _db_path: str | Path | None = None
-    _lock = threading.Lock()
-
-    def __new__(cls, db_path: str | Path | None = None) -> "DatabaseManager":
+    def __init__(self, db_path: str | Path | None = None) -> None:
         """
-        Create or return singleton instance.
-
-        Thread-safe via _lock to prevent race conditions during initialization.
-
         Args:
-            db_path: Path to SQLite database file (str for ':memory:', Path otherwise)
-
-        Returns:
-            DatabaseManager instance
+            db_path: Path to SQLite database file (str for ':memory:',
+                Path otherwise). Defaults to the repo-local data path.
         """
-        with cls._lock:
-            if cls._instance is None:
-                cls._instance = super().__new__(cls)
-                if db_path:
-                    cls._db_path = db_path
-                elif cls._db_path is None:
-                    # Default path
-                    cls._db_path = Path(__file__).parents[3] / "data" / "annotations.db"
-        return cls._instance
+        if db_path is None:
+            db_path = Path(__file__).parents[3] / "data" / "annotations.db"
+        self._db_path = db_path
 
     @contextmanager
     def get_connection(self) -> Any:
@@ -64,6 +53,11 @@ class DatabaseManager:
         conn.row_factory = sqlite3.Row  # Enable column access by name
         conn.execute("PRAGMA foreign_keys = ON")
         conn.execute("PRAGMA journal_mode=WAL")
+        # Wait instead of failing with "database is locked" when another
+        # worker/thread holds the write lock.
+        conn.execute("PRAGMA busy_timeout = 10000")
+        # Safe with WAL and considerably faster than FULL.
+        conn.execute("PRAGMA synchronous = NORMAL")
         try:
             yield conn
             conn.commit()
@@ -75,128 +69,13 @@ class DatabaseManager:
 
     def init_db(self) -> None:
         """
-        Initialize database schema.
+        Create or upgrade the database schema.
 
-        Creates tables, indices, and triggers if they don't exist.
-        Safe to call multiple times (idempotent).
+        Versioned via PRAGMA user_version; see models/migrations.py.
+        Safe to call multiple times.
         """
         with self.get_connection() as conn:
-            cursor = conn.cursor()
-
-            # Create users table
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS users (
-                    id TEXT PRIMARY KEY,
-                    username TEXT NOT NULL UNIQUE,
-                    email TEXT NOT NULL UNIQUE,
-                    password_hash TEXT NOT NULL,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    is_active INTEGER DEFAULT 1
-                )
-            """
-            )
-
-            # Create documents table
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS documents (
-                    id TEXT PRIMARY KEY,
-                    user_id TEXT NOT NULL,
-                    original_filename TEXT NOT NULL,
-                    file_path TEXT NOT NULL,
-                    page_count INTEGER NOT NULL,
-                    first_name TEXT DEFAULT '',
-                    last_name TEXT DEFAULT '',
-                    title TEXT DEFAULT '',
-                    year TEXT DEFAULT '',
-                    subject TEXT DEFAULT '',
-                    upload_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-                )
-            """
-            )
-
-            # Migrate existing database (add new columns if they don't exist)
-            migration_columns = [
-                "first_name TEXT DEFAULT ''",
-                "last_name TEXT DEFAULT ''",
-                "title TEXT DEFAULT ''",
-                "year TEXT DEFAULT ''",
-                "subject TEXT DEFAULT ''",
-                "user_id TEXT",
-            ]
-            for col_def in migration_columns:
-                try:
-                    cursor.execute(f"ALTER TABLE documents ADD COLUMN {col_def}")
-                except sqlite3.OperationalError:
-                    pass  # Column already exists
-
-            # Add is_admin column to users table if it doesn't exist
-            try:
-                cursor.execute(
-                    "ALTER TABLE users ADD COLUMN is_admin INTEGER DEFAULT 0"
-                )
-            except sqlite3.OperationalError:
-                pass  # Column already exists
-
-            # Add theme column to users table if it doesn't exist
-            try:
-                cursor.execute("ALTER TABLE users ADD COLUMN theme TEXT DEFAULT NULL")
-            except sqlite3.OperationalError:
-                pass  # Column already exists
-
-            # Create annotations table
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS annotations (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    doc_id TEXT NOT NULL,
-                    page_number INTEGER NOT NULL,
-                    note_text TEXT DEFAULT '',
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    FOREIGN KEY (doc_id) REFERENCES documents(id) ON DELETE CASCADE,
-                    UNIQUE(doc_id, page_number)
-                )
-            """
-            )
-
-            # Create indices for performance
-            cursor.execute(
-                """
-                CREATE INDEX IF NOT EXISTS idx_annotations_doc_id
-                ON annotations(doc_id)
-            """
-            )
-
-            cursor.execute(
-                """
-                CREATE INDEX IF NOT EXISTS idx_annotations_page
-                ON annotations(doc_id, page_number)
-            """
-            )
-
-            cursor.execute(
-                """
-                CREATE INDEX IF NOT EXISTS idx_annotations_updated_at
-                ON annotations(updated_at)
-            """
-            )
-
-            # Create trigger for automatic updated_at
-            cursor.execute(
-                """
-                CREATE TRIGGER IF NOT EXISTS update_annotation_timestamp
-                AFTER UPDATE ON annotations
-                FOR EACH ROW
-                BEGIN
-                    UPDATE annotations
-                    SET updated_at = CURRENT_TIMESTAMP
-                    WHERE id = NEW.id;
-                END
-            """
-            )
+            apply_migrations(conn)
 
     def create_document(
         self,
@@ -837,3 +716,16 @@ class DatabaseManager:
                 return bool(cursor.rowcount > 0)
         except sqlite3.Error:
             return False
+
+
+def get_db() -> DatabaseManager:
+    """
+    Return the application's DatabaseManager instance.
+
+    Created once per app in create_app() and stored in app.extensions,
+    so it always reflects the running app's DATABASE_PATH. Requires an
+    application context; background jobs receive the instance explicitly
+    instead of calling this.
+    """
+    db: DatabaseManager = current_app.extensions["db"]
+    return db

--- a/src/pdf_annotator/models/migrations.py
+++ b/src/pdf_annotator/models/migrations.py
@@ -122,7 +122,31 @@ def _m001_baseline(conn: sqlite3.Connection) -> None:
     )
 
 
-MIGRATIONS: list[Migration] = [_m001_baseline]
+def _m002_jobs(conn: sqlite3.Connection) -> None:
+    """Background job tracking for OCR and annotated-PDF export."""
+    conn.execute(
+        """
+        CREATE TABLE jobs (
+            id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            doc_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            result_path TEXT,
+            result_json TEXT,
+            error TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            started_at TIMESTAMP,
+            finished_at TIMESTAMP,
+            FOREIGN KEY (doc_id) REFERENCES documents(id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute("CREATE INDEX idx_jobs_doc_type_status ON jobs(doc_id, type, status)")
+    conn.execute("CREATE INDEX idx_jobs_status ON jobs(status)")
+
+
+MIGRATIONS: list[Migration] = [_m001_baseline, _m002_jobs]
 
 
 def apply_migrations(conn: sqlite3.Connection) -> None:

--- a/src/pdf_annotator/models/migrations.py
+++ b/src/pdf_annotator/models/migrations.py
@@ -1,0 +1,133 @@
+"""
+Versioned schema migrations, tracked via SQLite's PRAGMA user_version.
+
+Each entry in MIGRATIONS upgrades the schema by one version; a database
+at version N gets MIGRATIONS[N:] applied in order and is stamped after
+each step. New schema changes are added as a new function appended to
+MIGRATIONS — never by editing an existing one.
+"""
+
+import sqlite3
+from collections.abc import Callable
+
+Migration = Callable[[sqlite3.Connection], None]
+
+
+def _m001_baseline(conn: sqlite3.Connection) -> None:
+    """
+    Initial schema: users, documents, annotations, indices, trigger.
+
+    Deliberately idempotent (IF NOT EXISTS / try-ALTER): databases created
+    before schema versioning existed are at user_version 0 but already
+    contain some or all of this schema. Running the baseline converges
+    them and they get stamped to version 1 like a fresh database.
+    """
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id TEXT PRIMARY KEY,
+            username TEXT NOT NULL UNIQUE,
+            email TEXT NOT NULL UNIQUE,
+            password_hash TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            is_active INTEGER DEFAULT 1
+        )
+    """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS documents (
+            id TEXT PRIMARY KEY,
+            user_id TEXT NOT NULL,
+            original_filename TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            page_count INTEGER NOT NULL,
+            first_name TEXT DEFAULT '',
+            last_name TEXT DEFAULT '',
+            title TEXT DEFAULT '',
+            year TEXT DEFAULT '',
+            subject TEXT DEFAULT '',
+            upload_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+    """
+    )
+
+    # Columns added over time before versioned migrations existed; old
+    # databases may miss any subset of them.
+    legacy_columns = [
+        ("documents", "first_name TEXT DEFAULT ''"),
+        ("documents", "last_name TEXT DEFAULT ''"),
+        ("documents", "title TEXT DEFAULT ''"),
+        ("documents", "year TEXT DEFAULT ''"),
+        ("documents", "subject TEXT DEFAULT ''"),
+        ("documents", "user_id TEXT"),
+        ("users", "is_admin INTEGER DEFAULT 0"),
+        ("users", "theme TEXT DEFAULT NULL"),
+    ]
+    for table, col_def in legacy_columns:
+        try:
+            cursor.execute(f"ALTER TABLE {table} ADD COLUMN {col_def}")  # noqa: S608
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS annotations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            doc_id TEXT NOT NULL,
+            page_number INTEGER NOT NULL,
+            note_text TEXT DEFAULT '',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (doc_id) REFERENCES documents(id) ON DELETE CASCADE,
+            UNIQUE(doc_id, page_number)
+        )
+    """
+    )
+
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_annotations_doc_id
+        ON annotations(doc_id)
+    """
+    )
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_annotations_page
+        ON annotations(doc_id, page_number)
+    """
+    )
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_annotations_updated_at
+        ON annotations(updated_at)
+    """
+    )
+
+    cursor.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS update_annotation_timestamp
+        AFTER UPDATE ON annotations
+        FOR EACH ROW
+        BEGIN
+            UPDATE annotations
+            SET updated_at = CURRENT_TIMESTAMP
+            WHERE id = NEW.id;
+        END
+    """
+    )
+
+
+MIGRATIONS: list[Migration] = [_m001_baseline]
+
+
+def apply_migrations(conn: sqlite3.Connection) -> None:
+    """Bring the connected database up to the latest schema version."""
+    current = conn.execute("PRAGMA user_version").fetchone()[0]
+    for number, migration in enumerate(MIGRATIONS[current:], start=current + 1):
+        migration(conn)
+        conn.execute(f"PRAGMA user_version = {number}")

--- a/src/pdf_annotator/routes/_helpers.py
+++ b/src/pdf_annotator/routes/_helpers.py
@@ -1,0 +1,68 @@
+"""
+Shared helpers for route modules.
+"""
+
+from typing import Any
+
+from flask import abort, request
+from flask_login import current_user
+
+from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.utils.logger import get_logger
+from pdf_annotator.utils.validators import validate_doc_id
+
+logger = get_logger(__name__)
+
+# Endpoints under these paths answer errors as JSON; everything else gets
+# the HTML error page. Kept in sync with the blueprints' API surfaces.
+_JSON_PATH_PREFIXES = (
+    "/viewer/api/",
+    "/export",
+    "/delete/",
+    "/import",
+    "/upload",
+    "/ai/",
+    "/swb/",
+    "/auth/theme",
+)
+
+
+def wants_json() -> bool:
+    """Whether the current request should receive JSON error responses."""
+    if request.path.startswith(_JSON_PATH_PREFIXES):
+        return True
+    if request.accept_mimetypes.best == "application/json":
+        return True
+    return bool(request.is_json)
+
+
+def get_owned_document(doc_id: str) -> dict[str, Any]:
+    """
+    Validate doc_id, fetch the document, and verify ownership — or abort.
+
+    Aborts with 400 (invalid id), 404 (unknown document), or 403 (owned by
+    someone else). The app-level error handlers render the abort as JSON
+    or HTML depending on the request (see wants_json). Call this before
+    entering any try/except Exception block, which would otherwise swallow
+    the HTTPException into a 500.
+    """
+    is_valid, error_msg = validate_doc_id(doc_id)
+    if not is_valid:
+        abort(400, description=error_msg)
+
+    db = DatabaseManager()
+    doc_info = db.get_document(doc_id)
+
+    if not doc_info:
+        logger.warning("Document not found: %s", doc_id)
+        abort(404, description="Dokument nicht gefunden")
+
+    if doc_info.get("user_id") != current_user.id:
+        logger.warning(
+            "Unauthorized access: user %s tried to access document owned by %s",
+            current_user.id,
+            doc_info.get("user_id"),
+        )
+        abort(403, description="Nicht berechtigt")
+
+    return doc_info

--- a/src/pdf_annotator/routes/_helpers.py
+++ b/src/pdf_annotator/routes/_helpers.py
@@ -2,10 +2,13 @@
 Shared helpers for route modules.
 """
 
-from typing import Any
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar
 
-from flask import abort, request
+from flask import abort, jsonify, render_template, request
 from flask_login import current_user
+from werkzeug.exceptions import HTTPException
 
 from pdf_annotator.models.database import DatabaseManager
 from pdf_annotator.utils.logger import get_logger
@@ -66,3 +69,44 @@ def get_owned_document(doc_id: str) -> dict[str, Any]:
         abort(403, description="Nicht berechtigt")
 
     return doc_info
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def handle_errors(
+    message: str = "Interner Serverfehler",
+    html_message: str = "Ein interner Serverfehler ist aufgetreten.",
+) -> Callable[[F], F]:
+    """
+    Replace per-route try/except Exception blocks.
+
+    HTTPExceptions (aborts from get_owned_document etc.) are re-raised so
+    they reach the app error handlers. Any other exception is logged and
+    answered as 500 with the route's German message — JSON for API paths,
+    the HTML error page otherwise.
+    """
+
+    def decorator(f: F) -> F:
+        @wraps(f)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return f(*args, **kwargs)
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error("Error in %s: %s", request.path, e, exc_info=True)
+                if wants_json():
+                    return jsonify({"error": message}), 500
+                return (
+                    render_template(
+                        "error.html",
+                        error_title="Serverfehler",
+                        error_message=html_message,
+                    ),
+                    500,
+                )
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/src/pdf_annotator/routes/_helpers.py
+++ b/src/pdf_annotator/routes/_helpers.py
@@ -10,7 +10,7 @@ from flask import abort, jsonify, render_template, request
 from flask_login import current_user
 from werkzeug.exceptions import HTTPException
 
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import get_db
 from pdf_annotator.utils.logger import get_logger
 from pdf_annotator.utils.validators import validate_doc_id
 
@@ -53,7 +53,7 @@ def get_owned_document(doc_id: str) -> dict[str, Any]:
     if not is_valid:
         abort(400, description=error_msg)
 
-    db = DatabaseManager()
+    db = get_db()
     doc_info = db.get_document(doc_id)
 
     if not doc_info:

--- a/src/pdf_annotator/routes/admin.py
+++ b/src/pdf_annotator/routes/admin.py
@@ -10,7 +10,7 @@ from typing import Any
 from flask import Blueprint, Response, abort, jsonify, render_template
 from flask_login import current_user, login_required
 
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import DatabaseManager, get_db
 
 admin_bp = Blueprint("admin", __name__)
 
@@ -53,7 +53,7 @@ def _guard_user_action(
 
 def _toggle_user_flag(user_id: str, field: str) -> tuple[Response, int] | Response:
     spec = _TOGGLE_SPECS[field]
-    db = DatabaseManager()
+    db = get_db()
 
     user_data, error = _guard_user_action(
         db, user_id, spec["self_error"], spec["last_admin_error"]
@@ -94,7 +94,7 @@ def admin_required(f):
 @admin_required
 def index() -> str:
     """Display admin panel with user list."""
-    db = DatabaseManager()
+    db = get_db()
     users = db.get_all_users()
     return render_template("admin/index.html", users=users, current_user=current_user)
 
@@ -117,7 +117,7 @@ def toggle_admin(user_id: str) -> tuple[Response, int] | Response:
 @admin_required
 def delete_user(user_id: str) -> tuple[Response, int] | Response:
     """Delete a user and all their documents."""
-    db = DatabaseManager()
+    db = get_db()
 
     user_data, error = _guard_user_action(
         db,

--- a/src/pdf_annotator/routes/admin.py
+++ b/src/pdf_annotator/routes/admin.py
@@ -5,13 +5,76 @@ Provides endpoints for listing users and managing their status/privileges.
 """
 
 from functools import wraps
+from typing import Any
 
-from flask import Blueprint, abort, jsonify, render_template
+from flask import Blueprint, Response, abort, jsonify, render_template
 from flask_login import current_user, login_required
 
 from pdf_annotator.models.database import DatabaseManager
 
 admin_bp = Blueprint("admin", __name__)
+
+# Shared logic for the two flag-toggle endpoints; only field-specific
+# strings and the setter differ.
+_TOGGLE_SPECS: dict[str, dict[str, Any]] = {
+    "is_active": {
+        "setter": "set_user_active",
+        "self_error": "Sie können sich nicht selbst deaktivieren",
+        "last_admin_error": "Der letzte Admin kann nicht deaktiviert werden",
+        "messages": ("Benutzer aktiviert", "Benutzer deaktiviert"),
+    },
+    "is_admin": {
+        "setter": "set_user_admin",
+        "self_error": "Sie können sich nicht selbst entziehen",
+        "last_admin_error": "Der letzte Admin kann nicht entrollt werden",
+        "messages": ("Admin-Rechte erteilt", "Admin-Rechte entzogen"),
+    },
+}
+
+
+def _guard_user_action(
+    db: DatabaseManager, user_id: str, self_error: str, last_admin_error: str
+) -> tuple[dict[str, Any] | None, tuple[Response, int] | None]:
+    """Common preamble: user must exist, must not be the caller, and the
+    last admin is protected. Returns (user_data, None) or (None, error)."""
+    user_data = db.get_user_by_id(user_id)
+
+    if not user_data:
+        return None, (jsonify({"error": "Benutzer nicht gefunden"}), 404)
+
+    if user_id == current_user.id:
+        return None, (jsonify({"error": self_error}), 403)
+
+    if user_data["is_admin"] and db.count_admins() <= 1:
+        return None, (jsonify({"error": last_admin_error}), 403)
+
+    return user_data, None
+
+
+def _toggle_user_flag(user_id: str, field: str) -> tuple[Response, int] | Response:
+    spec = _TOGGLE_SPECS[field]
+    db = DatabaseManager()
+
+    user_data, error = _guard_user_action(
+        db, user_id, spec["self_error"], spec["last_admin_error"]
+    )
+    if error:
+        return error
+    assert user_data is not None
+
+    new_value = not user_data[field]
+    success = getattr(db, spec["setter"])(user_id, new_value)
+
+    if success:
+        message_on, message_off = spec["messages"]
+        return jsonify(
+            {
+                "success": True,
+                field: new_value,
+                "message": message_on if new_value else message_off,
+            }
+        )
+    return jsonify({"error": "Fehler beim Aktualisieren"}), 500
 
 
 def admin_required(f):
@@ -38,106 +101,33 @@ def index() -> str:
 
 @admin_bp.route("/user/<user_id>/toggle_active", methods=["POST"])
 @admin_required
-def toggle_active(user_id: str):
+def toggle_active(user_id: str) -> tuple[Response, int] | Response:
     """Toggle user active status (activate/deactivate)."""
-    db = DatabaseManager()
-    user_data = db.get_user_by_id(user_id)
-
-    if not user_data:
-        return jsonify({"error": "Benutzer nicht gefunden"}), 404
-
-    # Admin cannot deactivate themselves
-    if user_id == current_user.id:
-        return (
-            jsonify({"error": "Sie können sich nicht selbst deaktivieren"}),
-            403,
-        )
-
-    # Don't allow deactivating the last admin
-    if user_data["is_admin"]:
-        if db.count_admins() <= 1:
-            return (
-                jsonify({"error": "Der letzte Admin kann nicht deaktiviert werden"}),
-                403,
-            )
-
-    new_is_active = not user_data["is_active"]
-    success = db.set_user_active(user_id, new_is_active)
-
-    if success:
-        return jsonify(
-            {
-                "success": True,
-                "is_active": new_is_active,
-                "message": (
-                    "Benutzer aktiviert" if new_is_active else "Benutzer deaktiviert"
-                ),
-            }
-        )
-    return jsonify({"error": "Fehler beim Aktualisieren"}), 500
+    return _toggle_user_flag(user_id, "is_active")
 
 
 @admin_bp.route("/user/<user_id>/toggle_admin", methods=["POST"])
 @admin_required
-def toggle_admin(user_id: str):
+def toggle_admin(user_id: str) -> tuple[Response, int] | Response:
     """Toggle user admin status."""
-    db = DatabaseManager()
-    user_data = db.get_user_by_id(user_id)
-
-    if not user_data:
-        return jsonify({"error": "Benutzer nicht gefunden"}), 404
-
-    # Admin cannot remove their own admin privileges
-    if user_id == current_user.id:
-        return (
-            jsonify({"error": "Sie können sich nicht selbst entziehen"}),
-            403,
-        )
-
-    # Don't allow removing the last admin
-    if user_data["is_admin"]:
-        if db.count_admins() <= 1:
-            return (
-                jsonify({"error": "Der letzte Admin kann nicht entrollt werden"}),
-                403,
-            )
-
-    new_is_admin = not user_data["is_admin"]
-    success = db.set_user_admin(user_id, new_is_admin)
-
-    if success:
-        return jsonify(
-            {
-                "success": True,
-                "is_admin": new_is_admin,
-                "message": (
-                    "Admin-Rechte erteilt" if new_is_admin else "Admin-Rechte entzogen"
-                ),
-            }
-        )
-    return jsonify({"error": "Fehler beim Aktualisieren"}), 500
+    return _toggle_user_flag(user_id, "is_admin")
 
 
 @admin_bp.route("/user/<user_id>", methods=["DELETE"])
 @admin_required
-def delete_user(user_id: str):
+def delete_user(user_id: str) -> tuple[Response, int] | Response:
     """Delete a user and all their documents."""
     db = DatabaseManager()
-    user_data = db.get_user_by_id(user_id)
 
-    if not user_data:
-        return jsonify({"error": "Benutzer nicht gefunden"}), 404
-
-    # Admin cannot delete themselves
-    if user_id == current_user.id:
-        return jsonify({"error": "Sie können sich nicht selbst löschen"}), 403
-
-    # Don't allow deleting the last admin
-    if user_data["is_admin"]:
-        if db.count_admins() <= 1:
-            return jsonify(
-                {"error": "Der letzte Admin kann nicht gelöscht werden"}
-            ), 403
+    user_data, error = _guard_user_action(
+        db,
+        user_id,
+        "Sie können sich nicht selbst löschen",
+        "Der letzte Admin kann nicht gelöscht werden",
+    )
+    if error:
+        return error
+    assert user_data is not None
 
     success = db.delete_user(user_id)
 

--- a/src/pdf_annotator/routes/ai.py
+++ b/src/pdf_annotator/routes/ai.py
@@ -11,6 +11,7 @@ from typing import Any
 from flask import Blueprint, jsonify, request
 from flask_login import login_required
 
+from pdf_annotator.routes._helpers import handle_errors
 from pdf_annotator.services.ai_client import (
     AIConfigError,
     AIFeatureDisabledError,
@@ -32,6 +33,7 @@ MODES_REQUIRING_SOURCE_TEXT = {"edit", "context"}
 
 @ai_bp.route("/text", methods=["POST"])
 @login_required
+@handle_errors()
 def generate_or_edit_text() -> Any:
     """
     Edit selected note text, generate new note text, or formulate a note
@@ -93,7 +95,4 @@ def generate_or_edit_text() -> Any:
         return jsonify({"error": "KI-Dienst nicht konfiguriert"}), 503
     except AIProviderError as e:
         logger.error("AI provider error: %s", e)
-        return jsonify({"error": "Interner Serverfehler"}), 500
-    except Exception as e:
-        logger.error(f"Error in AI text endpoint: {e}", exc_info=True)
         return jsonify({"error": "Interner Serverfehler"}), 500

--- a/src/pdf_annotator/routes/auth.py
+++ b/src/pdf_annotator/routes/auth.py
@@ -26,7 +26,7 @@ from pdf_annotator.forms import (
     RegisterForm,
     _first_error,
 )
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import get_db
 from pdf_annotator.models.user import User
 
 auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
@@ -55,7 +55,7 @@ def login_post() -> ResponseReturnValue:
     username = form.username.data or ""
     password = form.password.data or ""
 
-    db = DatabaseManager()
+    db = get_db()
     user_data = db.get_user_by_username(username)
 
     if not user_data or not check_password_hash(user_data["password_hash"], password):
@@ -101,7 +101,7 @@ def _registration_blocked() -> ResponseReturnValue | None:
     """
     if current_app.config.get("REGISTRATION_ENABLED", True):
         return None
-    db = DatabaseManager()
+    db = get_db()
     if db.count_users() == 0:
         return None
     return (
@@ -156,7 +156,7 @@ def register_post() -> ResponseReturnValue:
     email = form.email.data or ""
     password = form.password.data or ""
 
-    db = DatabaseManager()
+    db = get_db()
 
     # Check if username already exists
     if db.get_user_by_username(username):
@@ -215,7 +215,7 @@ def change_password_post() -> ResponseReturnValue:
 
     # Verify the current password before any format validation, matching
     # the previous behavior (wrong current password wins with a 401).
-    db = DatabaseManager()
+    db = get_db()
     user_data = db.get_user_by_id(current_user.id)
 
     if not user_data or not check_password_hash(
@@ -256,6 +256,6 @@ def set_theme() -> ResponseReturnValue:
     theme = data.get("theme")
     if theme not in ("light", "dark", "brutalist", "compact"):
         return jsonify({"error": "Ungültiges Theme"}), 400
-    db = DatabaseManager()
+    db = get_db()
     db.set_user_theme(current_user.id, theme)
     return jsonify({"success": True})

--- a/src/pdf_annotator/routes/auth.py
+++ b/src/pdf_annotator/routes/auth.py
@@ -4,9 +4,18 @@ Authentication routes for login, logout, and registration.
 Provides endpoints for user authentication and session management.
 """
 
+import secrets
 import sqlite3
 
-from flask import Blueprint, jsonify, redirect, render_template, request, url_for
+from flask import (
+    Blueprint,
+    current_app,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from flask.typing import ResponseReturnValue
 from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -83,9 +92,36 @@ def logout() -> ResponseReturnValue:
     return redirect(url_for("auth.login"))
 
 
+def _registration_blocked() -> ResponseReturnValue | None:
+    """
+    Return a 403 response when self-registration is disabled.
+
+    The very first user may always register (a locked-down fresh install
+    still needs its initial admin account).
+    """
+    if current_app.config.get("REGISTRATION_ENABLED", True):
+        return None
+    db = DatabaseManager()
+    if db.count_users() == 0:
+        return None
+    return (
+        render_template(
+            "auth/register.html",
+            error=(
+                "Die Registrierung ist deaktiviert. "
+                "Bitte wenden Sie sich an den Administrator."
+            ),
+        ),
+        403,
+    )
+
+
 @auth_bp.route("/register", methods=["GET"])
 def register() -> ResponseReturnValue:
     """Display registration form."""
+    blocked = _registration_blocked()
+    if blocked:
+        return blocked
     return render_template("auth/register.html")
 
 
@@ -99,9 +135,22 @@ def register_post() -> ResponseReturnValue:
     Returns:
         Redirect to documents page on success, or re-render register with error
     """
+    blocked = _registration_blocked()
+    if blocked:
+        return blocked
+
     form = RegisterForm()
     if not form.validate_on_submit():
         return render_template("auth/register.html", error=_first_error(form)), 400
+
+    invite_code = current_app.config.get("REGISTRATION_INVITE_CODE")
+    if invite_code and not secrets.compare_digest(
+        form.invite_code.data or "", invite_code
+    ):
+        return (
+            render_template("auth/register.html", error="Ungültiger Einladungscode."),
+            403,
+        )
 
     username = form.username.data or ""
     email = form.email.data or ""

--- a/src/pdf_annotator/routes/auth.py
+++ b/src/pdf_annotator/routes/auth.py
@@ -11,6 +11,12 @@ from flask.typing import ResponseReturnValue
 from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.security import check_password_hash, generate_password_hash
 
+from pdf_annotator.forms import (
+    ChangePasswordForm,
+    LoginForm,
+    RegisterForm,
+    _first_error,
+)
 from pdf_annotator.models.database import DatabaseManager
 from pdf_annotator.models.user import User
 
@@ -33,16 +39,12 @@ def login_post() -> ResponseReturnValue:
     Returns:
         Redirect to documents page on success, or re-render login with error
     """
-    username = request.form.get("username", "").strip()
-    password = request.form.get("password", "")
+    form = LoginForm()
+    if not form.validate_on_submit():
+        return render_template("auth/login.html", error=_first_error(form)), 400
 
-    if not username or not password:
-        return (
-            render_template(
-                "auth/login.html", error="Benutzername und Passwort erforderlich."
-            ),
-            400,
-        )
+    username = form.username.data or ""
+    password = form.password.data or ""
 
     db = DatabaseManager()
     user_data = db.get_user_by_username(username)
@@ -97,57 +99,13 @@ def register_post() -> ResponseReturnValue:
     Returns:
         Redirect to documents page on success, or re-render register with error
     """
-    username = request.form.get("username", "").strip()
-    email = request.form.get("email", "").strip()
-    password = request.form.get("password", "")
-    password_confirm = request.form.get("password_confirm", "")
+    form = RegisterForm()
+    if not form.validate_on_submit():
+        return render_template("auth/register.html", error=_first_error(form)), 400
 
-    # Validation
-    if not username or not email or not password:
-        return (
-            render_template(
-                "auth/register.html",
-                error="Alle Felder erforderlich.",
-            ),
-            400,
-        )
-
-    if len(username) < 3 or len(username) > 50:
-        return (
-            render_template(
-                "auth/register.html",
-                error="Benutzername muss zwischen 3 und 50 Zeichen lang sein.",
-            ),
-            400,
-        )
-
-    if len(password) < 8:
-        return (
-            render_template(
-                "auth/register.html",
-                error="Passwort muss mindestens 8 Zeichen lang sein.",
-            ),
-            400,
-        )
-
-    if password != password_confirm:
-        return (
-            render_template(
-                "auth/register.html",
-                error="Passwörter stimmen nicht überein.",
-            ),
-            400,
-        )
-
-    # Check if email format is valid (basic check)
-    if "@" not in email or "." not in email.split("@")[1]:
-        return (
-            render_template(
-                "auth/register.html",
-                error="Ungültige E-Mail-Adresse.",
-            ),
-            400,
-        )
+    username = form.username.data or ""
+    email = form.email.data or ""
+    password = form.password.data or ""
 
     db = DatabaseManager()
 
@@ -204,15 +162,15 @@ def change_password_post() -> ResponseReturnValue:
     Returns:
         Redirect to documents page on success, or re-render form with error
     """
-    current_password = request.form.get("current_password", "")
-    new_password = request.form.get("new_password", "")
-    new_password_confirm = request.form.get("new_password_confirm", "")
+    form = ChangePasswordForm()
 
+    # Verify the current password before any format validation, matching
+    # the previous behavior (wrong current password wins with a 401).
     db = DatabaseManager()
     user_data = db.get_user_by_id(current_user.id)
 
     if not user_data or not check_password_hash(
-        user_data["password_hash"], current_password
+        user_data["password_hash"], form.current_password.data or ""
     ):
         return (
             render_template(
@@ -222,25 +180,15 @@ def change_password_post() -> ResponseReturnValue:
             401,
         )
 
-    if len(new_password) < 8:
+    if not form.validate_on_submit():
         return (
-            render_template(
-                "auth/change_password.html",
-                error="Neues Passwort muss mindestens 8 Zeichen lang sein.",
-            ),
+            render_template("auth/change_password.html", error=_first_error(form)),
             400,
         )
 
-    if new_password != new_password_confirm:
-        return (
-            render_template(
-                "auth/change_password.html",
-                error="Neue Passwörter stimmen nicht überein.",
-            ),
-            400,
-        )
-
-    db.update_password(current_user.id, generate_password_hash(new_password))
+    db.update_password(
+        current_user.id, generate_password_hash(form.new_password.data or "")
+    )
 
     return render_template(
         "auth/change_password.html", success="Passwort erfolgreich geändert."

--- a/src/pdf_annotator/routes/export.py
+++ b/src/pdf_annotator/routes/export.py
@@ -5,7 +5,6 @@ Handles PDF and Markdown export with downloads.
 """
 
 import json
-import time
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -32,27 +31,6 @@ logger = get_logger(__name__)
 
 # Create Blueprint
 export_bp = Blueprint("export", __name__, url_prefix="/export")
-
-# Max age for export files before cleanup (1 hour)
-EXPORT_MAX_AGE_SECONDS = 3600
-
-
-def cleanup_old_exports() -> None:
-    """Remove export files older than EXPORT_MAX_AGE_SECONDS."""
-    try:
-        export_folder = Path(current_app.config["EXPORT_FOLDER"])
-        if not export_folder.exists():
-            return
-
-        now = time.time()
-        for file_path in export_folder.iterdir():
-            if file_path.is_file():
-                age = now - file_path.stat().st_mtime
-                if age > EXPORT_MAX_AGE_SECONDS:
-                    file_path.unlink(missing_ok=True)
-                    logger.debug("Cleaned up old export: %s", file_path.name)
-    except Exception as e:
-        logger.warning(f"Export cleanup failed: {e}")
 
 
 @export_bp.route("/original/<doc_id>", methods=["GET"])
@@ -126,9 +104,6 @@ def export_pdf(doc_id: str) -> Any:
     db = get_db()
 
     logger.info(f"Exporting annotated PDF for document {doc_id}")
-
-    # Clean up old export files before creating new ones
-    cleanup_old_exports()
 
     # Get last edited timestamp from annotations
     annotations = db.get_all_annotations(doc_id)
@@ -230,9 +205,6 @@ def export_markdown(doc_id: str) -> Any:
     db = get_db()
 
     logger.info(f"Exporting Markdown for document {doc_id}")
-
-    # Clean up old export files before creating new ones
-    cleanup_old_exports()
 
     # Get last edited timestamp from annotations
     annotations = db.get_all_annotations(doc_id)

--- a/src/pdf_annotator/routes/export.py
+++ b/src/pdf_annotator/routes/export.py
@@ -4,16 +4,18 @@ Export route for PDF Annotator.
 Handles PDF and Markdown export with downloads.
 """
 
+import json
 import time
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from flask import Blueprint, current_app, jsonify
-from flask_login import login_required
+from flask import Blueprint, abort, current_app, jsonify
+from flask_login import current_user, login_required
 
 from pdf_annotator.models.database import get_db
 from pdf_annotator.routes._helpers import get_owned_document, handle_errors
+from pdf_annotator.services.jobs import submit_job
 from pdf_annotator.services.markdown_exporter import (
     export_to_markdown,
     generate_markdown_filename,
@@ -104,18 +106,20 @@ def export_pdf(doc_id: str) -> Any:
     """
     Export annotated PDF.
 
-    Creates PDF with annotations and timestamps, then sends as download.
+    The 300-DPI export runs as a background job: the response is 202 with
+    a job_id to poll via GET /viewer/api/jobs/<job_id>; the finished file
+    is fetched from GET /export/download/<job_id>.
 
     Args:
         doc_id: UUID of document
 
     Returns:
-        PDF file download or error response
+        JSON with job_id (202) or error response
 
     Example:
         POST /export/pdf/abc-123
 
-        Response: PDF file download
+        Response: {"success": true, "job_id": "..."}
     """
     doc_info = get_owned_document(doc_id)
 
@@ -145,26 +149,60 @@ def export_pdf(doc_id: str) -> Any:
     # Ensure export directory exists
     export_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Generate annotated PDF
-    success = create_annotated_pdf(
-        doc_id,
-        export_path,
-        db,
-        font_name=current_app.config.get("PDF_ANNOTATION_FONT", "courier"),
-        font_size=current_app.config.get("PDF_ANNOTATION_FONTSIZE", 9),
-        font_color=current_app.config.get("PDF_ANNOTATION_COLOR", (0, 0.5, 0)),
-    )
+    # Config values captured now — the runner must not touch current_app.
+    font_name = current_app.config.get("PDF_ANNOTATION_FONT", "courier")
+    font_size = current_app.config.get("PDF_ANNOTATION_FONTSIZE", 9)
+    font_color = current_app.config.get("PDF_ANNOTATION_COLOR", (0, 0.5, 0))
 
-    if not success:
-        logger.error(f"Failed to create annotated PDF for {doc_id}")
-        return (
-            jsonify({"error": "Fehler beim Erstellen des annotierten PDFs"}),
-            500,
+    def runner() -> dict[str, Any]:
+        success = create_annotated_pdf(
+            doc_id,
+            export_path,
+            db,
+            font_name=font_name,
+            font_size=font_size,
+            font_color=font_color,
         )
+        if not success:
+            raise RuntimeError("Fehler beim Erstellen des annotierten PDFs")
+        return {"result_path": str(export_path), "filename": export_filename}
 
-    # Send file
-    logger.info(f"Sending annotated PDF: {export_filename}")
-    return send_file_response(export_path, export_filename, "application/pdf")
+    job_id = submit_job(db, "export_pdf", doc_id, current_user.id, runner)
+
+    return jsonify({"success": True, "job_id": job_id}), 202
+
+
+@export_bp.route("/download/<job_id>", methods=["GET"])
+@login_required
+@handle_errors("Interner Serverfehler beim Download")
+def download_job_result(job_id: str) -> Any:
+    """
+    Download the artifact produced by a finished export job.
+
+    Args:
+        job_id: UUID of the export job
+
+    Returns:
+        File download (or Desktop-Mode JSON), 409 while the job is still
+        running, 404 for unknown jobs or vanished artifacts.
+    """
+    db = get_db()
+    job = db.get_job(job_id)
+
+    if not job:
+        abort(404, description="Job nicht gefunden")
+    if job["user_id"] != current_user.id:
+        abort(403, description="Nicht berechtigt")
+    if job["status"] != "done" or not job["result_path"]:
+        return jsonify({"error": "Export ist noch nicht fertig"}), 409
+
+    file_path = Path(job["result_path"])
+    if not file_path.is_file():
+        return jsonify({"error": "Exportdatei nicht mehr vorhanden"}), 404
+
+    result = json.loads(job["result_json"] or "{}")
+    filename = result.get("filename", file_path.name)
+    return send_file_response(file_path, filename, "application/pdf")
 
 
 @export_bp.route("/markdown/<doc_id>", methods=["POST"])

--- a/src/pdf_annotator/routes/export.py
+++ b/src/pdf_annotator/routes/export.py
@@ -10,9 +10,10 @@ from typing import Any
 from uuid import uuid4
 
 from flask import Blueprint, current_app, jsonify
-from flask_login import current_user, login_required
+from flask_login import login_required
 
 from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.routes._helpers import get_owned_document
 from pdf_annotator.services.markdown_exporter import (
     export_to_markdown,
     generate_markdown_filename,
@@ -23,7 +24,7 @@ from pdf_annotator.services.pdf_generator import (
 )
 from pdf_annotator.utils.downloads import send_file_response
 from pdf_annotator.utils.logger import get_logger
-from pdf_annotator.utils.validators import validate_doc_id, validate_file_path
+from pdf_annotator.utils.validators import validate_file_path
 
 logger = get_logger(__name__)
 
@@ -71,26 +72,9 @@ def download_original_pdf(doc_id: str) -> Any:
 
         Response: Original PDF file download
     """
+    doc_info = get_owned_document(doc_id)
+
     try:
-        is_valid, error_msg = validate_doc_id(doc_id)
-        if not is_valid:
-            return jsonify({"error": error_msg}), 400
-
-        db = DatabaseManager()
-        doc_info = db.get_document(doc_id)
-
-        if not doc_info:
-            logger.warning(f"Document not found: {doc_id}")
-            return jsonify({"error": "Dokument nicht gefunden"}), 404
-
-        # Check ownership
-        if doc_info.get("user_id") != current_user.id:
-            logger.warning(
-                f"Unauthorized access: user {current_user.id} tried to access "
-                f"document owned by {doc_info.get('user_id')}"
-            )
-            return jsonify({"error": "Nicht berechtigt"}), 403
-
         logger.info(f"Downloading original PDF for document {doc_id}")
 
         # Get file path
@@ -139,25 +123,10 @@ def export_pdf(doc_id: str) -> Any:
 
         Response: PDF file download
     """
+    doc_info = get_owned_document(doc_id)
+
     try:
-        is_valid, error_msg = validate_doc_id(doc_id)
-        if not is_valid:
-            return jsonify({"error": error_msg}), 400
-
         db = DatabaseManager()
-        doc_info = db.get_document(doc_id)
-
-        if not doc_info:
-            logger.warning(f"Document not found: {doc_id}")
-            return jsonify({"error": "Dokument nicht gefunden"}), 404
-
-        # Check ownership
-        if doc_info.get("user_id") != current_user.id:
-            logger.warning(
-                f"Unauthorized access: user {current_user.id} tried to access "
-                f"document owned by {doc_info.get('user_id')}"
-            )
-            return jsonify({"error": "Nicht berechtigt"}), 403
 
         logger.info(f"Exporting annotated PDF for document {doc_id}")
 
@@ -228,25 +197,10 @@ def export_markdown(doc_id: str) -> Any:
 
         Response: Markdown file download
     """
+    doc_info = get_owned_document(doc_id)
+
     try:
-        is_valid, error_msg = validate_doc_id(doc_id)
-        if not is_valid:
-            return jsonify({"error": error_msg}), 400
-
         db = DatabaseManager()
-        doc_info = db.get_document(doc_id)
-
-        if not doc_info:
-            logger.warning(f"Document not found: {doc_id}")
-            return jsonify({"error": "Dokument nicht gefunden"}), 404
-
-        # Check ownership
-        if doc_info.get("user_id") != current_user.id:
-            logger.warning(
-                f"Unauthorized access: user {current_user.id} tried to access "
-                f"document owned by {doc_info.get('user_id')}"
-            )
-            return jsonify({"error": "Nicht berechtigt"}), 403
 
         logger.info(f"Exporting Markdown for document {doc_id}")
 

--- a/src/pdf_annotator/routes/export.py
+++ b/src/pdf_annotator/routes/export.py
@@ -128,6 +128,7 @@ def export_pdf(doc_id: str) -> Any:
     font_name = current_app.config.get("PDF_ANNOTATION_FONT", "courier")
     font_size = current_app.config.get("PDF_ANNOTATION_FONTSIZE", 9)
     font_color = current_app.config.get("PDF_ANNOTATION_COLOR", (0, 0.5, 0))
+    upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
 
     def runner() -> dict[str, Any]:
         success = create_annotated_pdf(
@@ -137,6 +138,7 @@ def export_pdf(doc_id: str) -> Any:
             font_name=font_name,
             font_size=font_size,
             font_color=font_color,
+            upload_folder=upload_folder,
         )
         if not success:
             raise RuntimeError("Fehler beim Erstellen des annotierten PDFs")

--- a/src/pdf_annotator/routes/export.py
+++ b/src/pdf_annotator/routes/export.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 from flask import Blueprint, current_app, jsonify
 from flask_login import login_required
 
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import get_db
 from pdf_annotator.routes._helpers import get_owned_document, handle_errors
 from pdf_annotator.services.markdown_exporter import (
     export_to_markdown,
@@ -119,7 +119,7 @@ def export_pdf(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    db = DatabaseManager()
+    db = get_db()
 
     logger.info(f"Exporting annotated PDF for document {doc_id}")
 
@@ -189,7 +189,7 @@ def export_markdown(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    db = DatabaseManager()
+    db = get_db()
 
     logger.info(f"Exporting Markdown for document {doc_id}")
 

--- a/src/pdf_annotator/routes/export.py
+++ b/src/pdf_annotator/routes/export.py
@@ -13,7 +13,7 @@ from flask import Blueprint, current_app, jsonify
 from flask_login import login_required
 
 from pdf_annotator.models.database import DatabaseManager
-from pdf_annotator.routes._helpers import get_owned_document
+from pdf_annotator.routes._helpers import get_owned_document, handle_errors
 from pdf_annotator.services.markdown_exporter import (
     export_to_markdown,
     generate_markdown_filename,
@@ -55,6 +55,7 @@ def cleanup_old_exports() -> None:
 
 @export_bp.route("/original/<doc_id>", methods=["GET"])
 @login_required
+@handle_errors("Interner Serverfehler beim Download")
 def download_original_pdf(doc_id: str) -> Any:
     """
     Download original PDF file.
@@ -74,38 +75,31 @@ def download_original_pdf(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        logger.info(f"Downloading original PDF for document {doc_id}")
+    logger.info(f"Downloading original PDF for document {doc_id}")
 
-        # Get file path
-        file_path = Path(doc_info["file_path"])
+    # Get file path
+    file_path = Path(doc_info["file_path"])
 
-        # Validate path to prevent path traversal attacks
-        upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
-        is_valid, error_msg = validate_file_path(file_path, upload_folder)
-        if not is_valid:
-            logger.error(f"Path traversal attempt blocked: {file_path}")
-            return jsonify({"error": "Ungültiger Dateipfad"}), 400
+    # Validate path to prevent path traversal attacks
+    upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
+    is_valid, error_msg = validate_file_path(file_path, upload_folder)
+    if not is_valid:
+        logger.error(f"Path traversal attempt blocked: {file_path}")
+        return jsonify({"error": "Ungültiger Dateipfad"}), 400
 
-        if not file_path.exists():
-            logger.error(f"PDF file not found: {file_path}")
-            return jsonify({"error": "PDF-Datei nicht gefunden"}), 404
+    if not file_path.exists():
+        logger.error(f"PDF file not found: {file_path}")
+        return jsonify({"error": "PDF-Datei nicht gefunden"}), 404
 
-        # Send file
-        original_filename = doc_info["original_filename"]
-        logger.info(f"Sending original PDF: {original_filename}")
-        return send_file_response(file_path, original_filename, "application/pdf")
-
-    except Exception as e:
-        logger.error(
-            f"Error downloading original PDF for document {doc_id}: {e}",
-            exc_info=True,
-        )
-        return jsonify({"error": "Interner Serverfehler beim Download"}), 500
+    # Send file
+    original_filename = doc_info["original_filename"]
+    logger.info(f"Sending original PDF: {original_filename}")
+    return send_file_response(file_path, original_filename, "application/pdf")
 
 
 @export_bp.route("/pdf/<doc_id>", methods=["POST"])
 @login_required
+@handle_errors("Interner Serverfehler beim Export")
 def export_pdf(doc_id: str) -> Any:
     """
     Export annotated PDF.
@@ -125,61 +119,57 @@ def export_pdf(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        db = DatabaseManager()
+    db = DatabaseManager()
 
-        logger.info(f"Exporting annotated PDF for document {doc_id}")
+    logger.info(f"Exporting annotated PDF for document {doc_id}")
 
-        # Clean up old export files before creating new ones
-        cleanup_old_exports()
+    # Clean up old export files before creating new ones
+    cleanup_old_exports()
 
-        # Get last edited timestamp from annotations
-        annotations = db.get_all_annotations(doc_id)
-        last_edited = None
-        if annotations:
-            # Find the most recent updated_at timestamp
-            last_edited = max(ann["updated_at"] for ann in annotations)
+    # Get last edited timestamp from annotations
+    annotations = db.get_all_annotations(doc_id)
+    last_edited = None
+    if annotations:
+        # Find the most recent updated_at timestamp
+        last_edited = max(ann["updated_at"] for ann in annotations)
 
-        # Generate output filename with metadata
-        export_filename = generate_annotated_filename(doc_info, last_edited)
+    # Generate output filename with metadata
+    export_filename = generate_annotated_filename(doc_info, last_edited)
 
-        # Create unique temporary file path
-        export_id = str(uuid4())
-        export_path = (
-            Path(current_app.config["EXPORT_FOLDER"]) / f"{export_id}_{export_filename}"
+    # Create unique temporary file path
+    export_id = str(uuid4())
+    export_path = (
+        Path(current_app.config["EXPORT_FOLDER"]) / f"{export_id}_{export_filename}"
+    )
+
+    # Ensure export directory exists
+    export_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Generate annotated PDF
+    success = create_annotated_pdf(
+        doc_id,
+        export_path,
+        db,
+        font_name=current_app.config.get("PDF_ANNOTATION_FONT", "courier"),
+        font_size=current_app.config.get("PDF_ANNOTATION_FONTSIZE", 9),
+        font_color=current_app.config.get("PDF_ANNOTATION_COLOR", (0, 0.5, 0)),
+    )
+
+    if not success:
+        logger.error(f"Failed to create annotated PDF for {doc_id}")
+        return (
+            jsonify({"error": "Fehler beim Erstellen des annotierten PDFs"}),
+            500,
         )
 
-        # Ensure export directory exists
-        export_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Generate annotated PDF
-        success = create_annotated_pdf(
-            doc_id,
-            export_path,
-            db,
-            font_name=current_app.config.get("PDF_ANNOTATION_FONT", "courier"),
-            font_size=current_app.config.get("PDF_ANNOTATION_FONTSIZE", 9),
-            font_color=current_app.config.get("PDF_ANNOTATION_COLOR", (0, 0.5, 0)),
-        )
-
-        if not success:
-            logger.error(f"Failed to create annotated PDF for {doc_id}")
-            return (
-                jsonify({"error": "Fehler beim Erstellen des annotierten PDFs"}),
-                500,
-            )
-
-        # Send file
-        logger.info(f"Sending annotated PDF: {export_filename}")
-        return send_file_response(export_path, export_filename, "application/pdf")
-
-    except Exception as e:
-        logger.error(f"Error exporting PDF for document {doc_id}: {e}", exc_info=True)
-        return jsonify({"error": "Interner Serverfehler beim Export"}), 500
+    # Send file
+    logger.info(f"Sending annotated PDF: {export_filename}")
+    return send_file_response(export_path, export_filename, "application/pdf")
 
 
 @export_bp.route("/markdown/<doc_id>", methods=["POST"])
 @login_required
+@handle_errors("Interner Serverfehler beim Export")
 def export_markdown(doc_id: str) -> Any:
     """
     Export annotations as Markdown.
@@ -199,50 +189,42 @@ def export_markdown(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        db = DatabaseManager()
+    db = DatabaseManager()
 
-        logger.info(f"Exporting Markdown for document {doc_id}")
+    logger.info(f"Exporting Markdown for document {doc_id}")
 
-        # Clean up old export files before creating new ones
-        cleanup_old_exports()
+    # Clean up old export files before creating new ones
+    cleanup_old_exports()
 
-        # Get last edited timestamp from annotations
-        annotations = db.get_all_annotations(doc_id)
-        last_edited = None
-        if annotations:
-            # Find the most recent updated_at timestamp
-            last_edited = max(ann["updated_at"] for ann in annotations)
+    # Get last edited timestamp from annotations
+    annotations = db.get_all_annotations(doc_id)
+    last_edited = None
+    if annotations:
+        # Find the most recent updated_at timestamp
+        last_edited = max(ann["updated_at"] for ann in annotations)
 
-        # Generate output filename with metadata
-        export_filename = generate_markdown_filename(doc_info, last_edited)
+    # Generate output filename with metadata
+    export_filename = generate_markdown_filename(doc_info, last_edited)
 
-        # Create unique temporary file path
-        export_id = str(uuid4())
-        export_path = (
-            Path(current_app.config["EXPORT_FOLDER"]) / f"{export_id}_{export_filename}"
+    # Create unique temporary file path
+    export_id = str(uuid4())
+    export_path = (
+        Path(current_app.config["EXPORT_FOLDER"]) / f"{export_id}_{export_filename}"
+    )
+
+    # Ensure export directory exists
+    export_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Generate Markdown
+    success = export_to_markdown(doc_id, export_path, db)
+
+    if not success:
+        logger.error(f"Failed to create Markdown export for {doc_id}")
+        return (
+            jsonify({"error": "Fehler beim Erstellen der Markdown-Datei"}),
+            500,
         )
 
-        # Ensure export directory exists
-        export_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Generate Markdown
-        success = export_to_markdown(doc_id, export_path, db)
-
-        if not success:
-            logger.error(f"Failed to create Markdown export for {doc_id}")
-            return (
-                jsonify({"error": "Fehler beim Erstellen der Markdown-Datei"}),
-                500,
-            )
-
-        # Send file
-        logger.info(f"Sending Markdown file: {export_filename}")
-        return send_file_response(export_path, export_filename, "text/markdown")
-
-    except Exception as e:
-        logger.error(
-            f"Error exporting Markdown for document {doc_id}: {e}",
-            exc_info=True,
-        )
-        return jsonify({"error": "Interner Serverfehler beim Export"}), 500
+    # Send file
+    logger.info(f"Sending Markdown file: {export_filename}")
+    return send_file_response(export_path, export_filename, "text/markdown")

--- a/src/pdf_annotator/routes/upload.py
+++ b/src/pdf_annotator/routes/upload.py
@@ -21,7 +21,7 @@ from flask import (
 from flask_login import current_user, login_required
 
 from pdf_annotator.models.database import DatabaseManager
-from pdf_annotator.routes._helpers import get_owned_document
+from pdf_annotator.routes._helpers import get_owned_document, handle_errors
 from pdf_annotator.services.data_manager import DataManager
 from pdf_annotator.services.pdf_processor import get_page_count, validate_pdf
 from pdf_annotator.utils.downloads import send_file_response
@@ -70,6 +70,7 @@ def list_documents() -> str:
 
 @upload_bp.route("/upload", methods=["POST"])
 @login_required
+@handle_errors("Interner Serverfehler beim Upload")
 def upload_file() -> Any:
     """
     Handle PDF file upload.
@@ -86,132 +87,124 @@ def upload_file() -> Any:
     Example:
         curl -F "file=@document.pdf" http://localhost:5000/upload
     """
+    # Check if file is in request
+    if "file" not in request.files:
+        logger.warning("Upload attempt without file")
+        return jsonify({"error": "Keine Datei gefunden"}), 400
+
+    file = request.files["file"]
+
+    # Validate file
+    is_valid, error_msg = validate_uploaded_file(
+        file,
+        max_size=current_app.config["MAX_CONTENT_LENGTH"],
+        allowed_extensions=current_app.config["ALLOWED_EXTENSIONS"],
+    )
+
+    if not is_valid:
+        logger.warning(f"File validation failed: {error_msg}")
+        return jsonify({"error": error_msg}), 400
+
+    # Sanitize original filename
+    original_filename = sanitize_filename(file.filename)
+    logger.info(f"Processing upload: {original_filename}")
+
+    # Generate unique filename for storage
+    storage_id = str(uuid4())
+    file_extension = Path(original_filename).suffix
+    storage_filename = f"{storage_id}{file_extension}"
+    storage_path = Path(current_app.config["UPLOAD_FOLDER"]) / storage_filename
+
+    # Save file
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    file.save(str(storage_path))
+    logger.info(f"File saved to: {storage_path}")
+
+    # Validate PDF
+    if not validate_pdf(storage_path):
+        # Clean up invalid file
+        storage_path.unlink()
+        logger.error(f"Invalid PDF file: {original_filename}")
+        return (
+            jsonify(
+                {"error": "Ungültige PDF-Datei. Bitte versuchen Sie eine andere Datei."}
+            ),
+            400,
+        )
+
+    # Get page count
     try:
-        # Check if file is in request
-        if "file" not in request.files:
-            logger.warning("Upload attempt without file")
-            return jsonify({"error": "Keine Datei gefunden"}), 400
-
-        file = request.files["file"]
-
-        # Validate file
-        is_valid, error_msg = validate_uploaded_file(
-            file,
-            max_size=current_app.config["MAX_CONTENT_LENGTH"],
-            allowed_extensions=current_app.config["ALLOWED_EXTENSIONS"],
-        )
-
-        if not is_valid:
-            logger.warning(f"File validation failed: {error_msg}")
-            return jsonify({"error": error_msg}), 400
-
-        # Sanitize original filename
-        original_filename = sanitize_filename(file.filename)
-        logger.info(f"Processing upload: {original_filename}")
-
-        # Generate unique filename for storage
-        storage_id = str(uuid4())
-        file_extension = Path(original_filename).suffix
-        storage_filename = f"{storage_id}{file_extension}"
-        storage_path = Path(current_app.config["UPLOAD_FOLDER"]) / storage_filename
-
-        # Save file
-        storage_path.parent.mkdir(parents=True, exist_ok=True)
-        file.save(str(storage_path))
-        logger.info(f"File saved to: {storage_path}")
-
-        # Validate PDF
-        if not validate_pdf(storage_path):
-            # Clean up invalid file
-            storage_path.unlink()
-            logger.error(f"Invalid PDF file: {original_filename}")
-            return (
-                jsonify(
-                    {
-                        "error": "Ungültige PDF-Datei. Bitte versuchen Sie eine andere Datei."
-                    }
-                ),
-                400,
-            )
-
-        # Get page count
-        try:
-            page_count = get_page_count(storage_path)
-            logger.info(f"PDF has {page_count} pages")
-        except Exception as e:
-            # Clean up file
-            storage_path.unlink()
-            logger.error(f"Failed to get page count: {e}")
-            return (
-                jsonify(
-                    {
-                        "error": "Fehler beim Lesen der PDF-Datei. Ist die Datei beschädigt?"
-                    }
-                ),
-                400,
-            )
-
-        # Get metadata from form
-        first_name = request.form.get("first_name", "").strip()
-        last_name = request.form.get("last_name", "").strip()
-        title = request.form.get("title", "").strip()
-        year = request.form.get("year", "").strip()
-        subject = request.form.get("subject", "").strip()
-
-        # Truncate metadata to configured max lengths
-        max_name = current_app.config.get("MAX_NAME_LENGTH", 100)
-        max_title = current_app.config.get("MAX_TITLE_LENGTH", 200)
-        max_year = current_app.config.get("MAX_YEAR_LENGTH", 4)
-        max_subject = current_app.config.get("MAX_SUBJECT_LENGTH", 200)
-        first_name = first_name[:max_name]
-        last_name = last_name[:max_name]
-        title = title[:max_title]
-        year = year[:max_year]
-        subject = subject[:max_subject]
-
-        # Create database entry
-        db = DatabaseManager()
-        doc_id = db.create_document(
-            current_user.id,
-            original_filename,
-            str(storage_path),
-            page_count,
-            first_name,
-            last_name,
-            title,
-            year,
-            subject,
-        )
-
-        # Initialize empty annotations for all pages
-        for page_num in range(1, page_count + 1):
-            db.upsert_annotation(doc_id, page_num, "")
-
-        logger.info(f"Document created: {doc_id} with {page_count} pages")
-
-        # Return success response with redirect URL
-        # For AJAX requests, return JSON
-        if request.headers.get("Accept") == "application/json":
-            return jsonify(
-                {
-                    "success": True,
-                    "doc_id": doc_id,
-                    "page_count": page_count,
-                    "redirect_url": url_for("viewer.view_document", doc_id=doc_id),
-                }
-            )
-
-        # For regular form submit, redirect
-        flash(f"PDF erfolgreich hochgeladen: {original_filename}", "success")
-        return redirect(url_for("viewer.view_document", doc_id=doc_id))
-
+        page_count = get_page_count(storage_path)
+        logger.info(f"PDF has {page_count} pages")
     except Exception as e:
-        logger.error(f"Upload failed: {e}", exc_info=True)
-        return jsonify({"error": "Interner Serverfehler beim Upload"}), 500
+        # Clean up file
+        storage_path.unlink()
+        logger.error(f"Failed to get page count: {e}")
+        return (
+            jsonify(
+                {"error": "Fehler beim Lesen der PDF-Datei. Ist die Datei beschädigt?"}
+            ),
+            400,
+        )
+
+    # Get metadata from form
+    first_name = request.form.get("first_name", "").strip()
+    last_name = request.form.get("last_name", "").strip()
+    title = request.form.get("title", "").strip()
+    year = request.form.get("year", "").strip()
+    subject = request.form.get("subject", "").strip()
+
+    # Truncate metadata to configured max lengths
+    max_name = current_app.config.get("MAX_NAME_LENGTH", 100)
+    max_title = current_app.config.get("MAX_TITLE_LENGTH", 200)
+    max_year = current_app.config.get("MAX_YEAR_LENGTH", 4)
+    max_subject = current_app.config.get("MAX_SUBJECT_LENGTH", 200)
+    first_name = first_name[:max_name]
+    last_name = last_name[:max_name]
+    title = title[:max_title]
+    year = year[:max_year]
+    subject = subject[:max_subject]
+
+    # Create database entry
+    db = DatabaseManager()
+    doc_id = db.create_document(
+        current_user.id,
+        original_filename,
+        str(storage_path),
+        page_count,
+        first_name,
+        last_name,
+        title,
+        year,
+        subject,
+    )
+
+    # Initialize empty annotations for all pages
+    for page_num in range(1, page_count + 1):
+        db.upsert_annotation(doc_id, page_num, "")
+
+    logger.info(f"Document created: {doc_id} with {page_count} pages")
+
+    # Return success response with redirect URL
+    # For AJAX requests, return JSON
+    if request.headers.get("Accept") == "application/json":
+        return jsonify(
+            {
+                "success": True,
+                "doc_id": doc_id,
+                "page_count": page_count,
+                "redirect_url": url_for("viewer.view_document", doc_id=doc_id),
+            }
+        )
+
+    # For regular form submit, redirect
+    flash(f"PDF erfolgreich hochgeladen: {original_filename}", "success")
+    return redirect(url_for("viewer.view_document", doc_id=doc_id))
 
 
 @upload_bp.route("/delete/<doc_id>", methods=["DELETE"])
 @login_required
+@handle_errors("Interner Serverfehler beim Löschen")
 def delete_document(doc_id: str) -> Any:
     """
     Delete document, annotations, and PDF file for current user.
@@ -228,41 +221,37 @@ def delete_document(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        db = DatabaseManager()
+    db = DatabaseManager()
 
-        # Delete from database first (CASCADE deletes annotations)
-        # This prevents data loss if database deletion fails
-        success = db.delete_document(doc_id)
+    # Delete from database first (CASCADE deletes annotations)
+    # This prevents data loss if database deletion fails
+    success = db.delete_document(doc_id)
 
-        if not success:
-            logger.error(f"Failed to delete document from database: {doc_id}")
-            return jsonify({"error": "Fehler beim Löschen aus der Datenbank"}), 500
+    if not success:
+        logger.error(f"Failed to delete document from database: {doc_id}")
+        return jsonify({"error": "Fehler beim Löschen aus der Datenbank"}), 500
 
-        # Only delete file after successful database deletion
-        file_path = Path(doc_info["file_path"])
-        if file_path.exists():
-            try:
-                file_path.unlink()
-                logger.info(f"Deleted file: {file_path}")
-            except OSError as e:
-                logger.warning(
-                    f"File deletion failed but DB entry removed: {file_path}, {e}"
-                )
-                # Continue - file can be cleaned up later
-        else:
-            logger.warning(f"File not found during deletion: {file_path}")
+    # Only delete file after successful database deletion
+    file_path = Path(doc_info["file_path"])
+    if file_path.exists():
+        try:
+            file_path.unlink()
+            logger.info(f"Deleted file: {file_path}")
+        except OSError as e:
+            logger.warning(
+                f"File deletion failed but DB entry removed: {file_path}, {e}"
+            )
+            # Continue - file can be cleaned up later
+    else:
+        logger.warning(f"File not found during deletion: {file_path}")
 
-        logger.info(f"Document deleted: {doc_id}")
-        return jsonify({"success": True, "message": "Dokument erfolgreich gelöscht"})
-
-    except Exception as e:
-        logger.error(f"Error deleting document {doc_id}: {e}", exc_info=True)
-        return jsonify({"error": "Interner Serverfehler beim Löschen"}), 500
+    logger.info(f"Document deleted: {doc_id}")
+    return jsonify({"success": True, "message": "Dokument erfolgreich gelöscht"})
 
 
 @upload_bp.route("/export", methods=["GET"])
 @login_required
+@handle_errors("Fehler beim Exportieren der Daten")
 def export_data() -> Any:
     """
     Export all user's documents and annotations as ZIP archive.
@@ -274,29 +263,25 @@ def export_data() -> Any:
         GET /export
         Response: PDF_Annotator_Backup_20260123.zip
     """
-    try:
-        db = DatabaseManager()
-        upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
-        manager = DataManager(upload_folder)
+    db = DatabaseManager()
+    upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
+    manager = DataManager(upload_folder)
 
-        # Get user's documents
-        user_docs = db.get_all_documents(current_user.id)
-        doc_ids = [doc["id"] for doc in user_docs]
+    # Get user's documents
+    user_docs = db.get_all_documents(current_user.id)
+    doc_ids = [doc["id"] for doc in user_docs]
 
-        # Create export
-        zip_path = manager.export_data(doc_ids)
+    # Create export
+    zip_path = manager.export_data(doc_ids)
 
-        logger.info(f"Data exported to: {zip_path}")
+    logger.info(f"Data exported to: {zip_path}")
 
-        return send_file_response(zip_path, zip_path.name, "application/zip")
-
-    except Exception as e:
-        logger.error(f"Export failed: {e}", exc_info=True)
-        return jsonify({"error": "Fehler beim Exportieren der Daten"}), 500
+    return send_file_response(zip_path, zip_path.name, "application/zip")
 
 
 @upload_bp.route("/export/info", methods=["GET"])
 @login_required
+@handle_errors("Fehler beim Abrufen der Export-Informationen")
 def export_info() -> Any:
     """
     Get information about current user's data for export.
@@ -308,25 +293,21 @@ def export_info() -> Any:
         GET /export/info
         Response: {"document_count": 5, "annotation_count": 42, "estimated_size_mb": 12.5}
     """
-    try:
-        db = DatabaseManager()
-        upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
-        manager = DataManager(upload_folder)
+    db = DatabaseManager()
+    upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
+    manager = DataManager(upload_folder)
 
-        # Get user's documents
-        user_docs = db.get_all_documents(current_user.id)
-        doc_ids = [doc["id"] for doc in user_docs]
+    # Get user's documents
+    user_docs = db.get_all_documents(current_user.id)
+    doc_ids = [doc["id"] for doc in user_docs]
 
-        info = manager.get_export_info(doc_ids)
-        return jsonify(info)
-
-    except Exception as e:
-        logger.error(f"Export info failed: {e}", exc_info=True)
-        return jsonify({"error": "Fehler beim Abrufen der Export-Informationen"}), 500
+    info = manager.get_export_info(doc_ids)
+    return jsonify(info)
 
 
 @upload_bp.route("/import", methods=["POST"])
 @login_required
+@handle_errors("Fehler beim Importieren der Daten. Bitte versuchen Sie es später.")
 def import_data() -> Any:
     """
     Import data from ZIP archive and associate with current user.
@@ -420,10 +401,3 @@ def import_data() -> Any:
         elif "groß" in error_msg.lower() or "size" in error_msg.lower():
             error_msg = "Backup-Datei ist zu groß (max. 500 MB)"
         return jsonify({"error": error_msg}), 400
-    except Exception as e:
-        logger.error(f"Import failed: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Fehler beim Importieren der Daten. Bitte versuchen Sie es später."
-            }
-        ), 500

--- a/src/pdf_annotator/routes/upload.py
+++ b/src/pdf_annotator/routes/upload.py
@@ -21,13 +21,13 @@ from flask import (
 from flask_login import current_user, login_required
 
 from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.routes._helpers import get_owned_document
 from pdf_annotator.services.data_manager import DataManager
 from pdf_annotator.services.pdf_processor import get_page_count, validate_pdf
 from pdf_annotator.utils.downloads import send_file_response
 from pdf_annotator.utils.logger import get_logger
 from pdf_annotator.utils.validators import (
     sanitize_filename,
-    validate_doc_id,
     validate_uploaded_file,
 )
 
@@ -226,27 +226,10 @@ def delete_document(doc_id: str) -> Any:
         DELETE /delete/abc-123
         Response: {"success": true}
     """
+    doc_info = get_owned_document(doc_id)
+
     try:
-        is_valid, error_msg = validate_doc_id(doc_id)
-        if not is_valid:
-            return jsonify({"error": error_msg}), 400
-
         db = DatabaseManager()
-
-        # Get document info to access file path
-        doc_info = db.get_document(doc_id)
-
-        if not doc_info:
-            logger.warning(f"Delete attempt for non-existent document: {doc_id}")
-            return jsonify({"error": "Dokument nicht gefunden"}), 404
-
-        # Check ownership
-        if doc_info.get("user_id") != current_user.id:
-            logger.warning(
-                f"Unauthorized delete attempt: user {current_user.id} tried to delete "
-                f"document owned by {doc_info.get('user_id')}"
-            )
-            return jsonify({"error": "Nicht berechtigt"}), 403
 
         # Delete from database first (CASCADE deletes annotations)
         # This prevents data loss if database deletion fails

--- a/src/pdf_annotator/routes/upload.py
+++ b/src/pdf_annotator/routes/upload.py
@@ -20,7 +20,7 @@ from flask import (
 )
 from flask_login import current_user, login_required
 
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import get_db
 from pdf_annotator.routes._helpers import get_owned_document, handle_errors
 from pdf_annotator.services.data_manager import DataManager
 from pdf_annotator.services.pdf_processor import get_page_count, validate_pdf
@@ -60,7 +60,7 @@ def list_documents() -> str:
     Returns:
         str: Rendered HTML template
     """
-    db = DatabaseManager()
+    db = get_db()
     documents = db.get_all_documents(current_user.id)
 
     logger.info(f"Listing {len(documents)} documents for user {current_user.username}")
@@ -166,7 +166,7 @@ def upload_file() -> Any:
     subject = subject[:max_subject]
 
     # Create database entry
-    db = DatabaseManager()
+    db = get_db()
     doc_id = db.create_document(
         current_user.id,
         original_filename,
@@ -221,7 +221,7 @@ def delete_document(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    db = DatabaseManager()
+    db = get_db()
 
     # Delete from database first (CASCADE deletes annotations)
     # This prevents data loss if database deletion fails
@@ -263,7 +263,7 @@ def export_data() -> Any:
         GET /export
         Response: PDF_Annotator_Backup_20260123.zip
     """
-    db = DatabaseManager()
+    db = get_db()
     upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
     manager = DataManager(upload_folder)
 
@@ -293,7 +293,7 @@ def export_info() -> Any:
         GET /export/info
         Response: {"document_count": 5, "annotation_count": 42, "estimated_size_mb": 12.5}
     """
-    db = DatabaseManager()
+    db = get_db()
     upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
     manager = DataManager(upload_folder)
 

--- a/src/pdf_annotator/routes/viewer.py
+++ b/src/pdf_annotator/routes/viewer.py
@@ -10,9 +10,10 @@ from typing import Any
 import fitz
 from flask import Blueprint, Response, current_app, jsonify, render_template, request
 from flask.typing import ResponseReturnValue
-from flask_login import current_user, login_required
+from flask_login import login_required
 
 from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.routes._helpers import get_owned_document
 from pdf_annotator.services.pdf_processor import (
     clear_render_cache,
     clear_text_layout_cache,
@@ -22,7 +23,6 @@ from pdf_annotator.services.pdf_processor import (
 )
 from pdf_annotator.utils.logger import get_logger
 from pdf_annotator.utils.validators import (
-    validate_doc_id,
     validate_file_size,
     validate_file_type,
     validate_note_text,
@@ -33,35 +33,6 @@ logger = get_logger(__name__)
 
 # Create Blueprint
 viewer_bp = Blueprint("viewer", __name__, url_prefix="/viewer")
-
-
-def _get_doc_or_error(doc_id: str) -> tuple[dict, None] | tuple[None, tuple]:
-    """
-    Validate doc_id, fetch document, and verify ownership.
-
-    Returns (doc_info, None) on success or (None, error_response_tuple) on failure.
-    Used by all API endpoints to avoid repeating the same auth/ownership boilerplate.
-    """
-    is_valid, error_msg = validate_doc_id(doc_id)
-    if not is_valid:
-        return None, (jsonify({"error": error_msg}), 400)
-
-    db = DatabaseManager()
-    doc_info = db.get_document(doc_id)
-
-    if not doc_info:
-        logger.warning("Document not found: %s", doc_id)
-        return None, (jsonify({"error": "Dokument nicht gefunden"}), 404)
-
-    if doc_info.get("user_id") != current_user.id:
-        logger.warning(
-            "Unauthorized access: user %s tried to access document owned by %s",
-            current_user.id,
-            doc_info.get("user_id"),
-        )
-        return None, (jsonify({"error": "Nicht berechtigt"}), 403)
-
-    return doc_info, None
 
 
 @viewer_bp.route("/<doc_id>", methods=["GET"])
@@ -79,38 +50,9 @@ def view_document(doc_id: str) -> Any:
     Example:
         GET /viewer/abc-123-def-456
     """
+    doc_info = get_owned_document(doc_id)
+
     try:
-        is_valid, error_msg = validate_doc_id(doc_id)
-        if not is_valid:
-            return render_template(
-                "error.html",
-                error_title="Ungültige Anfrage",
-                error_message="Ungültige Dokument-ID.",
-            ), 400
-
-        db = DatabaseManager()
-        doc_info = db.get_document(doc_id)
-
-        if not doc_info:
-            logger.warning(f"Document not found: {doc_id}")
-            return render_template(
-                "error.html",
-                error_title="Dokument nicht gefunden",
-                error_message="Das Dokument wurde nicht gefunden.",
-            ), 404
-
-        # Check ownership
-        if doc_info.get("user_id") != current_user.id:
-            logger.warning(
-                f"Unauthorized access: user {current_user.id} tried to view "
-                f"document owned by {doc_info.get('user_id')}"
-            )
-            return render_template(
-                "error.html",
-                error_title="Nicht berechtigt",
-                error_message="Sie haben keine Berechtigung für dieses Dokument.",
-            ), 403
-
         logger.info(f"Viewing document: {doc_id} ({doc_info['original_filename']})")
 
         return render_template(
@@ -150,12 +92,9 @@ def get_page_image(doc_id: str, page_number: int) -> ResponseReturnValue:
     Example:
         GET /viewer/api/page/abc-123/1
     """
-    try:
-        doc_info, err = _get_doc_or_error(doc_id)
-        if err is not None:
-            return err
-        assert doc_info is not None
+    doc_info = get_owned_document(doc_id)
 
+    try:
         # Validate page number
         is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
         if not is_valid:
@@ -204,12 +143,9 @@ def get_page_text(doc_id: str, page_number: int) -> Any:
     Example:
         GET /viewer/api/page/abc-123/1/text
     """
-    try:
-        doc_info, err = _get_doc_or_error(doc_id)
-        if err is not None:
-            return err
-        assert doc_info is not None
+    doc_info = get_owned_document(doc_id)
 
+    try:
         is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
         if not is_valid:
             logger.warning(
@@ -262,12 +198,9 @@ def get_annotation(doc_id: str, page_number: int) -> Any:
             "updated_at": "2026-01-07 20:45:00"
         }
     """
-    try:
-        doc_info, err = _get_doc_or_error(doc_id)
-        if err is not None:
-            return err
-        assert doc_info is not None
+    doc_info = get_owned_document(doc_id)
 
+    try:
         db = DatabaseManager()
 
         # Validate page number
@@ -328,12 +261,9 @@ def save_annotation(doc_id: str, page_number: int) -> Any:
             "updated_at": "2026-01-07 20:45:00"
         }
     """
-    try:
-        doc_info, err = _get_doc_or_error(doc_id)
-        if err is not None:
-            return err
-        assert doc_info is not None
+    doc_info = get_owned_document(doc_id)
 
+    try:
         db = DatabaseManager()
 
         # Validate page number
@@ -393,11 +323,9 @@ def update_metadata(doc_id: str) -> Any:
         POST /viewer/api/metadata/abc-123
         Body: {"first_name": "Max", "last_name": "Mustermann", ...}
     """
-    try:
-        doc_info, err = _get_doc_or_error(doc_id)
-        if err is not None:
-            return err
+    get_owned_document(doc_id)
 
+    try:
         db = DatabaseManager()
 
         # Get metadata from request
@@ -502,12 +430,9 @@ def replace_pdf(doc_id: str) -> Any:
         POST /viewer/api/replace/abc-123
         File: new_version.pdf
     """
-    try:
-        doc_info, err = _get_doc_or_error(doc_id)
-        if err is not None:
-            return err
-        assert doc_info is not None
+    doc_info = get_owned_document(doc_id)
 
+    try:
         db = DatabaseManager()
 
         # Check if file was uploaded
@@ -586,12 +511,9 @@ def append_pdf(doc_id: str) -> Any:
         POST /viewer/api/append/abc-123
         File: additional_pages.pdf
     """
-    try:
-        doc_info, err = _get_doc_or_error(doc_id)
-        if err is not None:
-            return err
-        assert doc_info is not None
+    doc_info = get_owned_document(doc_id)
 
+    try:
         db = DatabaseManager()
 
         if "file" not in request.files:
@@ -701,13 +623,10 @@ def ocr_document(doc_id: str) -> Any:
     Returns:
         JSON with success status or error response
     """
+    doc_info = get_owned_document(doc_id)
+
     try:
         from pdf_annotator.services.ocr import OCRError, ocr_available, ocr_pdf
-
-        doc_info, err = _get_doc_or_error(doc_id)
-        if err is not None:
-            return err
-        assert doc_info is not None
 
         if not ocr_available():
             return jsonify({"error": "OCR ist auf diesem Server nicht verfügbar"}), 501
@@ -749,12 +668,9 @@ def delete_page(doc_id: str, page_number: int) -> Any:
     Returns:
         JSON response with new page_count or error
     """
-    try:
-        doc_info, err = _get_doc_or_error(doc_id)
-        if err is not None:
-            return err
-        assert doc_info is not None
+    doc_info = get_owned_document(doc_id)
 
+    try:
         db = DatabaseManager()
 
         # Validate page number

--- a/src/pdf_annotator/routes/viewer.py
+++ b/src/pdf_annotator/routes/viewer.py
@@ -12,7 +12,7 @@ from flask import Blueprint, Response, current_app, jsonify, render_template, re
 from flask.typing import ResponseReturnValue
 from flask_login import login_required
 
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import get_db
 from pdf_annotator.routes._helpers import get_owned_document, handle_errors
 from pdf_annotator.services.pdf_processor import (
     clear_render_cache,
@@ -175,7 +175,7 @@ def get_annotation(doc_id: str, page_number: int) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    db = DatabaseManager()
+    db = get_db()
 
     # Validate page number
     is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
@@ -229,7 +229,7 @@ def save_annotation(doc_id: str, page_number: int) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    db = DatabaseManager()
+    db = get_db()
 
     # Validate page number
     is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
@@ -282,7 +282,7 @@ def update_metadata(doc_id: str) -> Any:
     """
     get_owned_document(doc_id)
 
-    db = DatabaseManager()
+    db = get_db()
 
     # Get metadata from request
     data = request.get_json()
@@ -382,7 +382,7 @@ def replace_pdf(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    db = DatabaseManager()
+    db = get_db()
 
     # Check if file was uploaded
     if "file" not in request.files:
@@ -456,7 +456,7 @@ def append_pdf(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    db = DatabaseManager()
+    db = get_db()
 
     if "file" not in request.files:
         logger.warning("No file in request")
@@ -602,7 +602,7 @@ def delete_page(doc_id: str, page_number: int) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    db = DatabaseManager()
+    db = get_db()
 
     # Validate page number
     is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])

--- a/src/pdf_annotator/routes/viewer.py
+++ b/src/pdf_annotator/routes/viewer.py
@@ -4,16 +4,26 @@ Viewer route for PDF Annotator.
 Handles viewer page and API endpoints for PDF rendering and annotations.
 """
 
+import json
 from pathlib import Path
 from typing import Any
 
 import fitz
-from flask import Blueprint, Response, current_app, jsonify, render_template, request
+from flask import (
+    Blueprint,
+    Response,
+    abort,
+    current_app,
+    jsonify,
+    render_template,
+    request,
+)
 from flask.typing import ResponseReturnValue
-from flask_login import login_required
+from flask_login import current_user, login_required
 
 from pdf_annotator.models.database import get_db
 from pdf_annotator.routes._helpers import get_owned_document, handle_errors
+from pdf_annotator.services.jobs import submit_job
 from pdf_annotator.services.pdf_processor import (
     get_page_count,
     get_page_text_layout,
@@ -547,12 +557,15 @@ def ocr_document(doc_id: str) -> Any:
     Args:
         doc_id: UUID of document
 
+    OCR runs as a background job: the response is 202 with a job_id to
+    poll via GET /viewer/api/jobs/<job_id>.
+
     Returns:
-        JSON with success status or error response
+        JSON with job_id (202) or error response
     """
     doc_info = get_owned_document(doc_id)
 
-    from pdf_annotator.services.ocr import OCRError, ocr_available, ocr_pdf
+    from pdf_annotator.services.ocr import ocr_available, ocr_pdf
 
     if not ocr_available():
         return jsonify({"error": "OCR ist auf diesem Server nicht verfügbar"}), 501
@@ -562,13 +575,46 @@ def ocr_document(doc_id: str) -> Any:
         logger.error("Document file not found: %s", file_path)
         return jsonify({"error": "Dokumentdatei nicht gefunden"}), 404
 
-    logger.info("Running OCR for document %s", doc_id)
-    try:
-        ocr_pdf(file_path)
-    except OCRError as e:
-        return jsonify({"error": str(e)}), 500
+    db = get_db()
+    if db.get_active_job(doc_id, "ocr"):
+        return jsonify({"error": "OCR läuft bereits für dieses Dokument"}), 409
 
-    return jsonify({"success": True})
+    def runner() -> dict[str, Any]:
+        ocr_pdf(file_path)
+        return {}
+
+    logger.info("Starting OCR job for document %s", doc_id)
+    job_id = submit_job(db, "ocr", doc_id, current_user.id, runner)
+
+    return jsonify({"success": True, "job_id": job_id}), 202
+
+
+@viewer_bp.route("/api/jobs/<job_id>", methods=["GET"])
+@login_required
+@handle_errors()
+def get_job_status(job_id: str) -> Any:
+    """
+    Poll the status of a background job (OCR, PDF export).
+
+    Returns:
+        JSON with status (pending|running|done|error), error message if
+        any, and the job's result data.
+    """
+    db = get_db()
+    job = db.get_job(job_id)
+
+    if not job:
+        abort(404, description="Job nicht gefunden")
+    if job["user_id"] != current_user.id:
+        abort(403, description="Nicht berechtigt")
+
+    return jsonify(
+        {
+            "status": job["status"],
+            "error": job["error"],
+            "result": json.loads(job["result_json"]) if job["result_json"] else {},
+        }
+    )
 
 
 @viewer_bp.route("/api/page/<doc_id>/<int:page_number>", methods=["DELETE"])

--- a/src/pdf_annotator/routes/viewer.py
+++ b/src/pdf_annotator/routes/viewer.py
@@ -13,7 +13,7 @@ from flask.typing import ResponseReturnValue
 from flask_login import login_required
 
 from pdf_annotator.models.database import DatabaseManager
-from pdf_annotator.routes._helpers import get_owned_document
+from pdf_annotator.routes._helpers import get_owned_document, handle_errors
 from pdf_annotator.services.pdf_processor import (
     clear_render_cache,
     clear_text_layout_cache,
@@ -37,6 +37,7 @@ viewer_bp = Blueprint("viewer", __name__, url_prefix="/viewer")
 
 @viewer_bp.route("/<doc_id>", methods=["GET"])
 @login_required
+@handle_errors(html_message="Beim Laden des Dokuments ist ein Fehler aufgetreten.")
 def view_document(doc_id: str) -> Any:
     """
     Render viewer page for document.
@@ -52,32 +53,24 @@ def view_document(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        logger.info(f"Viewing document: {doc_id} ({doc_info['original_filename']})")
+    logger.info(f"Viewing document: {doc_id} ({doc_info['original_filename']})")
 
-        return render_template(
-            "viewer.html",
-            doc_id=doc_id,
-            original_filename=doc_info["original_filename"],
-            page_count=doc_info["page_count"],
-            first_name=doc_info.get("first_name", ""),
-            last_name=doc_info.get("last_name", ""),
-            title=doc_info.get("title", ""),
-            year=doc_info.get("year", ""),
-            subject=doc_info.get("subject", ""),
-        )
-
-    except Exception as e:
-        logger.error(f"Error viewing document {doc_id}: {e}", exc_info=True)
-        return render_template(
-            "error.html",
-            error_title="Serverfehler",
-            error_message="Beim Laden des Dokuments ist ein Fehler aufgetreten.",
-        ), 500
+    return render_template(
+        "viewer.html",
+        doc_id=doc_id,
+        original_filename=doc_info["original_filename"],
+        page_count=doc_info["page_count"],
+        first_name=doc_info.get("first_name", ""),
+        last_name=doc_info.get("last_name", ""),
+        title=doc_info.get("title", ""),
+        year=doc_info.get("year", ""),
+        subject=doc_info.get("subject", ""),
+    )
 
 
 @viewer_bp.route("/api/page/<doc_id>/<int:page_number>", methods=["GET"])
 @login_required
+@handle_errors()
 def get_page_image(doc_id: str, page_number: int) -> ResponseReturnValue:
     """
     Render PDF page as PNG image.
@@ -94,38 +87,29 @@ def get_page_image(doc_id: str, page_number: int) -> ResponseReturnValue:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        # Validate page number
-        is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
-        if not is_valid:
-            logger.warning(
-                "Invalid page number %d for document %s", page_number, doc_id
-            )
-            return jsonify({"error": error_msg}), 400
+    # Validate page number
+    is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
+    if not is_valid:
+        logger.warning("Invalid page number %d for document %s", page_number, doc_id)
+        return jsonify({"error": error_msg}), 400
 
-        # Render page
-        dpi = current_app.config.get("PDF_RENDER_DPI", 300)
-        image_bytes = render_page_to_image(doc_info["file_path"], page_number, dpi=dpi)
+    # Render page
+    dpi = current_app.config.get("PDF_RENDER_DPI", 300)
+    image_bytes = render_page_to_image(doc_info["file_path"], page_number, dpi=dpi)
 
-        if image_bytes is None:
-            logger.error(f"Failed to render page {page_number} of document {doc_id}")
-            return jsonify({"error": "Fehler beim Rendern der Seite"}), 500
+    if image_bytes is None:
+        logger.error(f"Failed to render page {page_number} of document {doc_id}")
+        return jsonify({"error": "Fehler beim Rendern der Seite"}), 500
 
-        # Return PNG image with cache headers
-        resp = Response(image_bytes, mimetype="image/png")
-        resp.headers["Cache-Control"] = "private, max-age=300"
-        return resp
-
-    except Exception as e:
-        logger.error(
-            f"Error rendering page {page_number} of {doc_id}: {e}",
-            exc_info=True,
-        )
-        return jsonify({"error": "Interner Serverfehler"}), 500
+    # Return PNG image with cache headers
+    resp = Response(image_bytes, mimetype="image/png")
+    resp.headers["Cache-Control"] = "private, max-age=300"
+    return resp
 
 
 @viewer_bp.route("/api/page/<doc_id>/<int:page_number>/text", methods=["GET"])
 @login_required
+@handle_errors()
 def get_page_text(doc_id: str, page_number: int) -> Any:
     """
     Get word-level text with bounding boxes for a PDF page.
@@ -145,39 +129,30 @@ def get_page_text(doc_id: str, page_number: int) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
+    is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
+    if not is_valid:
+        logger.warning("Invalid page number %d for document %s", page_number, doc_id)
+        return jsonify({"error": error_msg}), 400
+
     try:
-        is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
-        if not is_valid:
-            logger.warning(
-                "Invalid page number %d for document %s", page_number, doc_id
-            )
-            return jsonify({"error": error_msg}), 400
-
-        try:
-            layout = get_page_text_layout(doc_info["file_path"], page_number)
-        except Exception as e:
-            logger.error(
-                "Failed to extract text layout for page %d of %s: %s",
-                page_number,
-                doc_id,
-                e,
-            )
-            return jsonify({"error": "Fehler beim Extrahieren des Textes"}), 500
-
-        resp = jsonify(layout)
-        resp.headers["Cache-Control"] = "private, max-age=300"
-        return resp
-
+        layout = get_page_text_layout(doc_info["file_path"], page_number)
     except Exception as e:
         logger.error(
-            f"Error getting text layout for page {page_number} of {doc_id}: {e}",
-            exc_info=True,
+            "Failed to extract text layout for page %d of %s: %s",
+            page_number,
+            doc_id,
+            e,
         )
-        return jsonify({"error": "Interner Serverfehler"}), 500
+        return jsonify({"error": "Fehler beim Extrahieren des Textes"}), 500
+
+    resp = jsonify(layout)
+    resp.headers["Cache-Control"] = "private, max-age=300"
+    return resp
 
 
 @viewer_bp.route("/api/annotation/<doc_id>/<int:page_number>", methods=["GET"])
 @login_required
+@handle_errors()
 def get_annotation(doc_id: str, page_number: int) -> Any:
     """
     Get annotation for specific page.
@@ -200,41 +175,32 @@ def get_annotation(doc_id: str, page_number: int) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        db = DatabaseManager()
+    db = DatabaseManager()
 
-        # Validate page number
-        is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
-        if not is_valid:
-            logger.warning(
-                "Invalid page number %d for document %s", page_number, doc_id
-            )
-            return jsonify({"error": error_msg}), 400
+    # Validate page number
+    is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
+    if not is_valid:
+        logger.warning("Invalid page number %d for document %s", page_number, doc_id)
+        return jsonify({"error": error_msg}), 400
 
-        # Get annotation
-        annotation = db.get_annotation(doc_id, page_number)
+    # Get annotation
+    annotation = db.get_annotation(doc_id, page_number)
 
-        if annotation:
-            return jsonify(
-                {
-                    "note_text": annotation["note_text"],
-                    "updated_at": str(annotation["updated_at"]),
-                }
-            )
-        else:
-            # Return empty annotation
-            return jsonify({"note_text": "", "updated_at": None})
-
-    except Exception as e:
-        logger.error(
-            f"Error getting annotation for page {page_number} of {doc_id}: {e}",
-            exc_info=True,
+    if annotation:
+        return jsonify(
+            {
+                "note_text": annotation["note_text"],
+                "updated_at": str(annotation["updated_at"]),
+            }
         )
-        return jsonify({"error": "Interner Serverfehler"}), 500
+    else:
+        # Return empty annotation
+        return jsonify({"note_text": "", "updated_at": None})
 
 
 @viewer_bp.route("/api/annotation/<doc_id>/<int:page_number>", methods=["POST"])
 @login_required
+@handle_errors()
 def save_annotation(doc_id: str, page_number: int) -> Any:
     """
     Save or update annotation for specific page.
@@ -263,52 +229,43 @@ def save_annotation(doc_id: str, page_number: int) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        db = DatabaseManager()
+    db = DatabaseManager()
 
-        # Validate page number
-        is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
-        if not is_valid:
-            logger.warning(
-                "Invalid page number %d for document %s", page_number, doc_id
-            )
-            return jsonify({"error": error_msg}), 400
+    # Validate page number
+    is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
+    if not is_valid:
+        logger.warning("Invalid page number %d for document %s", page_number, doc_id)
+        return jsonify({"error": error_msg}), 400
 
-        # Get note text from request
-        data = request.get_json()
-        if not data:
-            logger.warning("No JSON data in request")
-            return jsonify({"error": "Keine Daten gesendet"}), 400
+    # Get note text from request
+    data = request.get_json()
+    if not data:
+        logger.warning("No JSON data in request")
+        return jsonify({"error": "Keine Daten gesendet"}), 400
 
-        note_text = data.get("note_text", "")
+    note_text = data.get("note_text", "")
 
-        # Validate note text
-        is_valid, error_msg = validate_note_text(note_text)
-        if not is_valid:
-            logger.warning(f"Invalid note text: {error_msg}")
-            return jsonify({"error": error_msg}), 400
+    # Validate note text
+    is_valid, error_msg = validate_note_text(note_text)
+    if not is_valid:
+        logger.warning(f"Invalid note text: {error_msg}")
+        return jsonify({"error": error_msg}), 400
 
-        # Save annotation
-        db.upsert_annotation(doc_id, page_number, note_text)
+    # Save annotation
+    db.upsert_annotation(doc_id, page_number, note_text)
 
-        # Get updated annotation to return timestamp
-        annotation = db.get_annotation(doc_id, page_number)
-        assert annotation is not None
+    # Get updated annotation to return timestamp
+    annotation = db.get_annotation(doc_id, page_number)
+    assert annotation is not None
 
-        logger.info(f"Saved annotation for page {page_number} of document {doc_id}")
+    logger.info(f"Saved annotation for page {page_number} of document {doc_id}")
 
-        return jsonify({"success": True, "updated_at": str(annotation["updated_at"])})
-
-    except Exception as e:
-        logger.error(
-            f"Error saving annotation for page {page_number} of {doc_id}: {e}",
-            exc_info=True,
-        )
-        return jsonify({"error": "Interner Serverfehler"}), 500
+    return jsonify({"success": True, "updated_at": str(annotation["updated_at"])})
 
 
 @viewer_bp.route("/api/metadata/<doc_id>", methods=["POST"])
 @login_required
+@handle_errors()
 def update_metadata(doc_id: str) -> Any:
     """
     Update document metadata.
@@ -325,95 +282,88 @@ def update_metadata(doc_id: str) -> Any:
     """
     get_owned_document(doc_id)
 
-    try:
-        db = DatabaseManager()
+    db = DatabaseManager()
 
-        # Get metadata from request
-        data = request.get_json()
-        if not data:
-            logger.warning("No JSON data in request")
-            return jsonify({"error": "Keine Daten gesendet"}), 400
+    # Get metadata from request
+    data = request.get_json()
+    if not data:
+        logger.warning("No JSON data in request")
+        return jsonify({"error": "Keine Daten gesendet"}), 400
 
-        # Extract metadata fields
-        first_name = data.get("first_name", "").strip()
-        last_name = data.get("last_name", "").strip()
-        title = data.get("title", "").strip()
-        year = data.get("year", "").strip()
-        subject = data.get("subject", "").strip()
+    # Extract metadata fields
+    first_name = data.get("first_name", "").strip()
+    last_name = data.get("last_name", "").strip()
+    title = data.get("title", "").strip()
+    year = data.get("year", "").strip()
+    subject = data.get("subject", "").strip()
 
-        # Validate input lengths
-        if len(first_name) > current_app.config["MAX_NAME_LENGTH"]:
-            return (
-                jsonify(
-                    {
-                        "error": f"Vorname zu lang (max. {current_app.config['MAX_NAME_LENGTH']} Zeichen)"
-                    }
-                ),
-                400,
-            )
-        if len(last_name) > current_app.config["MAX_NAME_LENGTH"]:
-            return (
-                jsonify(
-                    {
-                        "error": f"Nachname zu lang (max. {current_app.config['MAX_NAME_LENGTH']} Zeichen)"
-                    }
-                ),
-                400,
-            )
-        if len(title) > current_app.config["MAX_TITLE_LENGTH"]:
-            return (
-                jsonify(
-                    {
-                        "error": f"Titel zu lang (max. {current_app.config['MAX_TITLE_LENGTH']} Zeichen)"
-                    }
-                ),
-                400,
-            )
-        if len(year) > current_app.config["MAX_YEAR_LENGTH"]:
-            return (
-                jsonify(
-                    {
-                        "error": f"Jahr zu lang (max. {current_app.config['MAX_YEAR_LENGTH']} Zeichen)"
-                    }
-                ),
-                400,
-            )
-        if len(subject) > current_app.config["MAX_SUBJECT_LENGTH"]:
-            return (
-                jsonify(
-                    {
-                        "error": f"Thema zu lang (max. {current_app.config['MAX_SUBJECT_LENGTH']} Zeichen)"
-                    }
-                ),
-                400,
-            )
-
-        # Update metadata in database
-        success = db.update_document_metadata(
-            doc_id, first_name, last_name, title, year, subject
+    # Validate input lengths
+    if len(first_name) > current_app.config["MAX_NAME_LENGTH"]:
+        return (
+            jsonify(
+                {
+                    "error": f"Vorname zu lang (max. {current_app.config['MAX_NAME_LENGTH']} Zeichen)"
+                }
+            ),
+            400,
+        )
+    if len(last_name) > current_app.config["MAX_NAME_LENGTH"]:
+        return (
+            jsonify(
+                {
+                    "error": f"Nachname zu lang (max. {current_app.config['MAX_NAME_LENGTH']} Zeichen)"
+                }
+            ),
+            400,
+        )
+    if len(title) > current_app.config["MAX_TITLE_LENGTH"]:
+        return (
+            jsonify(
+                {
+                    "error": f"Titel zu lang (max. {current_app.config['MAX_TITLE_LENGTH']} Zeichen)"
+                }
+            ),
+            400,
+        )
+    if len(year) > current_app.config["MAX_YEAR_LENGTH"]:
+        return (
+            jsonify(
+                {
+                    "error": f"Jahr zu lang (max. {current_app.config['MAX_YEAR_LENGTH']} Zeichen)"
+                }
+            ),
+            400,
+        )
+    if len(subject) > current_app.config["MAX_SUBJECT_LENGTH"]:
+        return (
+            jsonify(
+                {
+                    "error": f"Thema zu lang (max. {current_app.config['MAX_SUBJECT_LENGTH']} Zeichen)"
+                }
+            ),
+            400,
         )
 
-        if not success:
-            logger.error(f"Failed to update metadata for document {doc_id}")
-            return (
-                jsonify({"error": "Fehler beim Aktualisieren der Metadaten"}),
-                500,
-            )
+    # Update metadata in database
+    success = db.update_document_metadata(
+        doc_id, first_name, last_name, title, year, subject
+    )
 
-        logger.info(f"Updated metadata for document {doc_id}")
-
-        return jsonify({"success": True})
-
-    except Exception as e:
-        logger.error(
-            f"Error updating metadata for document {doc_id}: {e}",
-            exc_info=True,
+    if not success:
+        logger.error(f"Failed to update metadata for document {doc_id}")
+        return (
+            jsonify({"error": "Fehler beim Aktualisieren der Metadaten"}),
+            500,
         )
-        return jsonify({"error": "Interner Serverfehler"}), 500
+
+    logger.info(f"Updated metadata for document {doc_id}")
+
+    return jsonify({"success": True})
 
 
 @viewer_bp.route("/api/replace/<doc_id>", methods=["POST"])
 @login_required
+@handle_errors()
 def replace_pdf(doc_id: str) -> Any:
     """
     Replace existing PDF with a new version.
@@ -432,71 +382,64 @@ def replace_pdf(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        db = DatabaseManager()
+    db = DatabaseManager()
 
-        # Check if file was uploaded
-        if "file" not in request.files:
-            logger.warning("No file in request")
-            return jsonify({"error": "Keine Datei hochgeladen"}), 400
+    # Check if file was uploaded
+    if "file" not in request.files:
+        logger.warning("No file in request")
+        return jsonify({"error": "Keine Datei hochgeladen"}), 400
 
-        file = request.files["file"]
+    file = request.files["file"]
 
-        if file.filename == "":
-            logger.warning("Empty filename")
-            return jsonify({"error": "Kein Dateiname"}), 400
+    if file.filename == "":
+        logger.warning("Empty filename")
+        return jsonify({"error": "Kein Dateiname"}), 400
 
-        # Validate file type
-        is_valid, error_msg = validate_file_type(file.filename)
-        if not is_valid:
-            logger.warning(f"Invalid file type: {file.filename}")
-            return jsonify({"error": error_msg}), 400
+    # Validate file type
+    is_valid, error_msg = validate_file_type(file.filename)
+    if not is_valid:
+        logger.warning(f"Invalid file type: {file.filename}")
+        return jsonify({"error": error_msg}), 400
 
-        # Validate file size
-        file.seek(0, 2)  # Seek to end
-        file_size = file.tell()
-        file.seek(0)  # Reset to beginning
+    # Validate file size
+    file.seek(0, 2)  # Seek to end
+    file_size = file.tell()
+    file.seek(0)  # Reset to beginning
 
-        is_valid, error_msg = validate_file_size(
-            file_size, current_app.config["MAX_CONTENT_LENGTH"]
-        )
-        if not is_valid:
-            logger.warning(f"File too large: {file_size} bytes")
-            return jsonify({"error": error_msg}), 400
+    is_valid, error_msg = validate_file_size(
+        file_size, current_app.config["MAX_CONTENT_LENGTH"]
+    )
+    if not is_valid:
+        logger.warning(f"File too large: {file_size} bytes")
+        return jsonify({"error": error_msg}), 400
 
-        logger.info(f"Replacing PDF for document {doc_id}")
+    logger.info(f"Replacing PDF for document {doc_id}")
 
-        file_path = Path(doc_info["file_path"])
-        if not file_path.is_file():
-            logger.error("Document file not found: %s", file_path)
-            return jsonify({"error": "Dokumentdatei nicht gefunden"}), 404
+    file_path = Path(doc_info["file_path"])
+    if not file_path.is_file():
+        logger.error("Document file not found: %s", file_path)
+        return jsonify({"error": "Dokumentdatei nicht gefunden"}), 404
 
-        # Save new file (overwrites old one)
-        file.save(file_path)
-        logger.info("Saved new PDF to: %s", file_path)
+    # Save new file (overwrites old one)
+    file.save(file_path)
+    logger.info("Saved new PDF to: %s", file_path)
 
-        # Clear render + text caches so stale data is not served
-        clear_render_cache()
-        clear_text_layout_cache()
+    # Clear render + text caches so stale data is not served
+    clear_render_cache()
+    clear_text_layout_cache()
 
-        # Get new page count and update database
-        new_page_count = get_page_count(file_path)
-        db.update_page_count(doc_id, new_page_count)
+    # Get new page count and update database
+    new_page_count = get_page_count(file_path)
+    db.update_page_count(doc_id, new_page_count)
 
-        logger.info("Successfully replaced PDF for document %s", doc_id)
+    logger.info("Successfully replaced PDF for document %s", doc_id)
 
-        return jsonify({"success": True, "page_count": new_page_count})
-
-    except Exception as e:
-        logger.error(
-            f"Error replacing PDF for document {doc_id}: {e}",
-            exc_info=True,
-        )
-        return jsonify({"error": "Interner Serverfehler"}), 500
+    return jsonify({"success": True, "page_count": new_page_count})
 
 
 @viewer_bp.route("/api/append/<doc_id>", methods=["POST"])
 @login_required
+@handle_errors()
 def append_pdf(doc_id: str) -> Any:
     """
     Append pages from another PDF to the end of an existing document.
@@ -513,102 +456,95 @@ def append_pdf(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
+    db = DatabaseManager()
+
+    if "file" not in request.files:
+        logger.warning("No file in request")
+        return jsonify({"error": "Keine Datei hochgeladen"}), 400
+
+    file = request.files["file"]
+
+    if file.filename == "":
+        logger.warning("Empty filename")
+        return jsonify({"error": "Kein Dateiname"}), 400
+
+    is_valid, error_msg = validate_file_type(file.filename)
+    if not is_valid:
+        logger.warning(f"Invalid file type: {file.filename}")
+        return jsonify({"error": error_msg}), 400
+
+    file.seek(0, 2)
+    file_size = file.tell()
+    file.seek(0)
+
+    is_valid, error_msg = validate_file_size(
+        file_size, current_app.config["MAX_CONTENT_LENGTH"]
+    )
+    if not is_valid:
+        logger.warning(f"File too large: {file_size} bytes")
+        return jsonify({"error": error_msg}), 400
+
+    file_path = Path(doc_info["file_path"])
+    if not file_path.is_file():
+        logger.error(f"Document file not found: {file_path}")
+        return jsonify({"error": "Dokumentdatei nicht gefunden"}), 404
+
+    # Save uploaded PDF to temp file
+    tmp_new = file_path.with_suffix(".append.pdf")
+    file.save(tmp_new)
+
     try:
-        db = DatabaseManager()
+        original_doc = fitz.open(str(file_path))
+        new_doc = fitz.open(str(tmp_new))
+        added_pages = len(new_doc)
 
-        if "file" not in request.files:
-            logger.warning("No file in request")
-            return jsonify({"error": "Keine Datei hochgeladen"}), 400
+        original_doc.insert_pdf(new_doc)
 
-        file = request.files["file"]
+        tmp_save = file_path.with_suffix(".tmp.pdf")
+        original_doc.save(str(tmp_save), deflate=True)
+        original_doc.close()
+        new_doc.close()
 
-        if file.filename == "":
-            logger.warning("Empty filename")
-            return jsonify({"error": "Kein Dateiname"}), 400
+        tmp_save.replace(file_path)
+    finally:
+        if tmp_new.exists():
+            tmp_new.unlink()
 
-        is_valid, error_msg = validate_file_type(file.filename)
-        if not is_valid:
-            logger.warning(f"Invalid file type: {file.filename}")
-            return jsonify({"error": error_msg}), 400
+    clear_render_cache()
+    clear_text_layout_cache()
 
-        file.seek(0, 2)
-        file_size = file.tell()
-        file.seek(0)
-
-        is_valid, error_msg = validate_file_size(
-            file_size, current_app.config["MAX_CONTENT_LENGTH"]
+    old_page_count = doc_info["page_count"]
+    new_page_count = old_page_count + added_pages
+    with db.get_connection() as conn:
+        conn.execute(
+            "UPDATE documents SET page_count = ? WHERE id = ?",
+            (new_page_count, doc_id),
         )
-        if not is_valid:
-            logger.warning(f"File too large: {file_size} bytes")
-            return jsonify({"error": error_msg}), 400
-
-        file_path = Path(doc_info["file_path"])
-        if not file_path.is_file():
-            logger.error(f"Document file not found: {file_path}")
-            return jsonify({"error": "Dokumentdatei nicht gefunden"}), 404
-
-        # Save uploaded PDF to temp file
-        tmp_new = file_path.with_suffix(".append.pdf")
-        file.save(tmp_new)
-
-        try:
-            original_doc = fitz.open(str(file_path))
-            new_doc = fitz.open(str(tmp_new))
-            added_pages = len(new_doc)
-
-            original_doc.insert_pdf(new_doc)
-
-            tmp_save = file_path.with_suffix(".tmp.pdf")
-            original_doc.save(str(tmp_save), deflate=True)
-            original_doc.close()
-            new_doc.close()
-
-            tmp_save.replace(file_path)
-        finally:
-            if tmp_new.exists():
-                tmp_new.unlink()
-
-        clear_render_cache()
-        clear_text_layout_cache()
-
-        old_page_count = doc_info["page_count"]
-        new_page_count = old_page_count + added_pages
-        with db.get_connection() as conn:
+        for p in range(old_page_count + 1, new_page_count + 1):
             conn.execute(
-                "UPDATE documents SET page_count = ? WHERE id = ?",
-                (new_page_count, doc_id),
+                """INSERT INTO annotations (doc_id, page_number, note_text)
+                   VALUES (?, ?, '')
+                   ON CONFLICT(doc_id, page_number) DO NOTHING""",
+                (doc_id, p),
             )
-            for p in range(old_page_count + 1, new_page_count + 1):
-                conn.execute(
-                    """INSERT INTO annotations (doc_id, page_number, note_text)
-                       VALUES (?, ?, '')
-                       ON CONFLICT(doc_id, page_number) DO NOTHING""",
-                    (doc_id, p),
-                )
 
-        logger.info(
-            f"Appended {added_pages} pages to document {doc_id}, "
-            f"new page count: {new_page_count}"
-        )
+    logger.info(
+        f"Appended {added_pages} pages to document {doc_id}, "
+        f"new page count: {new_page_count}"
+    )
 
-        return jsonify(
-            {
-                "success": True,
-                "page_count": new_page_count,
-                "added_pages": added_pages,
-            }
-        )
-
-    except Exception as e:
-        logger.error(
-            f"Error appending PDF to document {doc_id}: {e}",
-            exc_info=True,
-        )
-        return jsonify({"error": "Interner Serverfehler"}), 500
+    return jsonify(
+        {
+            "success": True,
+            "page_count": new_page_count,
+            "added_pages": added_pages,
+        }
+    )
 
 
 @viewer_bp.route("/api/ocr/<doc_id>", methods=["POST"])
 @login_required
+@handle_errors()
 def ocr_document(doc_id: str) -> Any:
     """
     Run OCR on the document's PDF, adding a searchable text layer.
@@ -625,35 +561,31 @@ def ocr_document(doc_id: str) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
+    from pdf_annotator.services.ocr import OCRError, ocr_available, ocr_pdf
+
+    if not ocr_available():
+        return jsonify({"error": "OCR ist auf diesem Server nicht verfügbar"}), 501
+
+    file_path = Path(doc_info["file_path"])
+    if not file_path.is_file():
+        logger.error("Document file not found: %s", file_path)
+        return jsonify({"error": "Dokumentdatei nicht gefunden"}), 404
+
+    logger.info("Running OCR for document %s", doc_id)
     try:
-        from pdf_annotator.services.ocr import OCRError, ocr_available, ocr_pdf
+        ocr_pdf(file_path)
+    except OCRError as e:
+        return jsonify({"error": str(e)}), 500
 
-        if not ocr_available():
-            return jsonify({"error": "OCR ist auf diesem Server nicht verfügbar"}), 501
+    clear_render_cache()
+    clear_text_layout_cache()
 
-        file_path = Path(doc_info["file_path"])
-        if not file_path.is_file():
-            logger.error("Document file not found: %s", file_path)
-            return jsonify({"error": "Dokumentdatei nicht gefunden"}), 404
-
-        logger.info("Running OCR for document %s", doc_id)
-        try:
-            ocr_pdf(file_path)
-        except OCRError as e:
-            return jsonify({"error": str(e)}), 500
-
-        clear_render_cache()
-        clear_text_layout_cache()
-
-        return jsonify({"success": True})
-
-    except Exception as e:
-        logger.error(f"Error running OCR for document {doc_id}: {e}", exc_info=True)
-        return jsonify({"error": "Interner Serverfehler"}), 500
+    return jsonify({"success": True})
 
 
 @viewer_bp.route("/api/page/<doc_id>/<int:page_number>", methods=["DELETE"])
 @login_required
+@handle_errors()
 def delete_page(doc_id: str, page_number: int) -> Any:
     """
     Delete a page from the PDF document.
@@ -670,53 +602,45 @@ def delete_page(doc_id: str, page_number: int) -> Any:
     """
     doc_info = get_owned_document(doc_id)
 
-    try:
-        db = DatabaseManager()
+    db = DatabaseManager()
 
-        # Validate page number
-        is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
-        if not is_valid:
-            return jsonify({"error": error_msg}), 400
+    # Validate page number
+    is_valid, error_msg = validate_page_number(page_number, doc_info["page_count"])
+    if not is_valid:
+        return jsonify({"error": error_msg}), 400
 
-        # Must have more than 1 page
-        if doc_info["page_count"] <= 1:
-            return (
-                jsonify({"error": "Die letzte Seite kann nicht gelöscht werden"}),
-                400,
-            )
-
-        # Delete page from PDF (fitz uses 0-indexed pages)
-        file_path = Path(doc_info["file_path"])
-        if not file_path.is_file():
-            logger.error(f"Document file not found: {file_path}")
-            return jsonify({"error": "Dokumentdatei nicht gefunden"}), 404
-
-        pdf_doc = fitz.open(str(file_path))
-        pdf_doc.delete_page(page_number - 1)
-        tmp_path = file_path.with_suffix(".tmp.pdf")
-        pdf_doc.save(str(tmp_path), deflate=True)
-        pdf_doc.close()
-        tmp_path.replace(file_path)
-
-        # Clear render + text caches
-        clear_render_cache()
-        clear_text_layout_cache()
-
-        # Delete annotation, renumber subsequent pages and decrement count atomically
-        db.delete_annotation_and_renumber(doc_id, page_number)
-
-        new_page_count = doc_info["page_count"] - 1
-
-        logger.info(
-            f"Deleted page {page_number} from document {doc_id}, "
-            f"new page count: {new_page_count}"
+    # Must have more than 1 page
+    if doc_info["page_count"] <= 1:
+        return (
+            jsonify({"error": "Die letzte Seite kann nicht gelöscht werden"}),
+            400,
         )
 
-        return jsonify({"success": True, "page_count": new_page_count})
+    # Delete page from PDF (fitz uses 0-indexed pages)
+    file_path = Path(doc_info["file_path"])
+    if not file_path.is_file():
+        logger.error(f"Document file not found: {file_path}")
+        return jsonify({"error": "Dokumentdatei nicht gefunden"}), 404
 
-    except Exception as e:
-        logger.error(
-            f"Error deleting page {page_number} from {doc_id}: {e}",
-            exc_info=True,
-        )
-        return jsonify({"error": "Interner Serverfehler"}), 500
+    pdf_doc = fitz.open(str(file_path))
+    pdf_doc.delete_page(page_number - 1)
+    tmp_path = file_path.with_suffix(".tmp.pdf")
+    pdf_doc.save(str(tmp_path), deflate=True)
+    pdf_doc.close()
+    tmp_path.replace(file_path)
+
+    # Clear render + text caches
+    clear_render_cache()
+    clear_text_layout_cache()
+
+    # Delete annotation, renumber subsequent pages and decrement count atomically
+    db.delete_annotation_and_renumber(doc_id, page_number)
+
+    new_page_count = doc_info["page_count"] - 1
+
+    logger.info(
+        f"Deleted page {page_number} from document {doc_id}, "
+        f"new page count: {new_page_count}"
+    )
+
+    return jsonify({"success": True, "page_count": new_page_count})

--- a/src/pdf_annotator/routes/viewer.py
+++ b/src/pdf_annotator/routes/viewer.py
@@ -15,8 +15,6 @@ from flask_login import login_required
 from pdf_annotator.models.database import get_db
 from pdf_annotator.routes._helpers import get_owned_document, handle_errors
 from pdf_annotator.services.pdf_processor import (
-    clear_render_cache,
-    clear_text_layout_cache,
     get_page_count,
     get_page_text_layout,
     render_page_to_image,
@@ -424,10 +422,6 @@ def replace_pdf(doc_id: str) -> Any:
     file.save(file_path)
     logger.info("Saved new PDF to: %s", file_path)
 
-    # Clear render + text caches so stale data is not served
-    clear_render_cache()
-    clear_text_layout_cache()
-
     # Get new page count and update database
     new_page_count = get_page_count(file_path)
     db.update_page_count(doc_id, new_page_count)
@@ -510,9 +504,6 @@ def append_pdf(doc_id: str) -> Any:
         if tmp_new.exists():
             tmp_new.unlink()
 
-    clear_render_cache()
-    clear_text_layout_cache()
-
     old_page_count = doc_info["page_count"]
     new_page_count = old_page_count + added_pages
     with db.get_connection() as conn:
@@ -577,9 +568,6 @@ def ocr_document(doc_id: str) -> Any:
     except OCRError as e:
         return jsonify({"error": str(e)}), 500
 
-    clear_render_cache()
-    clear_text_layout_cache()
-
     return jsonify({"success": True})
 
 
@@ -628,10 +616,6 @@ def delete_page(doc_id: str, page_number: int) -> Any:
     pdf_doc.save(str(tmp_path), deflate=True)
     pdf_doc.close()
     tmp_path.replace(file_path)
-
-    # Clear render + text caches
-    clear_render_cache()
-    clear_text_layout_cache()
 
     # Delete annotation, renumber subsequent pages and decrement count atomically
     db.delete_annotation_and_renumber(doc_id, page_number)

--- a/src/pdf_annotator/services/cleanup.py
+++ b/src/pdf_annotator/services/cleanup.py
@@ -1,0 +1,132 @@
+"""
+Periodic maintenance, moved off the request path.
+
+One daemon thread per process wakes every CLEANUP_INTERVAL_SECONDS and:
+- deletes export artifacts older than EXPORT_MAX_AGE_SECONDS
+- flips orphaned background jobs to 'error' (killed worker, hung tool)
+- expires finished job rows and unlinks their artifacts
+- prunes the render cache to its size budget
+
+Every task is idempotent, so correctness never depends on exclusion;
+with multiple Gunicorn workers a non-blocking file lock merely skips
+redundant rounds. The same mechanism works unchanged in the
+single-process desktop app.
+"""
+
+import random
+import threading
+import time
+from pathlib import Path
+from typing import IO, TYPE_CHECKING
+
+from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.services import render_cache
+from pdf_annotator.services.jobs import (
+    FINISHED_JOB_RETENTION_SECONDS,
+    JOB_STALE_SECONDS,
+)
+from pdf_annotator.utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+logger = get_logger(__name__)
+
+CLEANUP_INTERVAL_SECONDS = 15 * 60
+JITTER_SECONDS = 60
+STARTUP_DELAY_SECONDS = 10
+
+# Max age for export files before cleanup (1 hour)
+EXPORT_MAX_AGE_SECONDS = 3600
+
+
+def cleanup_old_exports(
+    export_folder: Path, max_age_seconds: int = EXPORT_MAX_AGE_SECONDS
+) -> None:
+    """Remove export files older than max_age_seconds."""
+    try:
+        if not export_folder.exists():
+            return
+
+        now = time.time()
+        for file_path in export_folder.iterdir():
+            if file_path.is_file():
+                age = now - file_path.stat().st_mtime
+                if age > max_age_seconds:
+                    file_path.unlink(missing_ok=True)
+                    logger.debug("Cleaned up old export: %s", file_path.name)
+    except Exception as e:
+        logger.warning(f"Export cleanup failed: {e}")
+
+
+def run_cleanup_once(
+    db: DatabaseManager,
+    export_folder: Path,
+    cache_folder: Path,
+    cache_max_bytes: int,
+) -> None:
+    """Run one maintenance round. Each task is independently idempotent."""
+    cleanup_old_exports(export_folder)
+
+    stale = db.mark_stale_jobs_failed(JOB_STALE_SECONDS)
+    if stale:
+        logger.info("Marked %d orphaned background jobs as failed", stale)
+
+    for path_str in db.delete_finished_jobs(FINISHED_JOB_RETENTION_SECONDS):
+        Path(path_str).unlink(missing_ok=True)
+
+    render_cache.prune(cache_folder, cache_max_bytes)
+
+
+def _try_lock(lock_path: Path) -> IO[str] | None:
+    """
+    Take a non-blocking exclusive flock; None when another process holds it.
+
+    On platforms without fcntl (Windows dev) the lock is skipped — every
+    task is idempotent, the lock only avoids duplicate work.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        return open(lock_path, "w")  # noqa: SIM115 - held for the round
+
+    handle = open(lock_path, "w")  # noqa: SIM115 - held for the round
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        return None
+    return handle
+
+
+def start_cleanup_thread(app: "Flask") -> threading.Thread:
+    """
+    Start the per-process cleanup daemon thread for this app.
+
+    The first round runs shortly after startup so jobs orphaned by a
+    previous crash/deploy are recovered promptly.
+    """
+    export_folder = Path(app.config["EXPORT_FOLDER"])
+    cache_folder = Path(app.config["RENDER_CACHE_FOLDER"])
+    cache_max_bytes = int(app.config["RENDER_CACHE_MAX_BYTES"])
+    db: DatabaseManager = app.extensions["db"]
+    lock_path = export_folder.parent / "cleanup.lock"
+    stop = threading.Event()
+
+    def loop() -> None:
+        stop.wait(STARTUP_DELAY_SECONDS)
+        while not stop.is_set():
+            lock = _try_lock(lock_path)
+            if lock is not None:
+                try:
+                    run_cleanup_once(db, export_folder, cache_folder, cache_max_bytes)
+                except Exception as e:
+                    logger.warning("Cleanup round failed: %s", e, exc_info=True)
+                finally:
+                    lock.close()
+            stop.wait(CLEANUP_INTERVAL_SECONDS + random.uniform(0, JITTER_SECONDS))
+
+    thread = threading.Thread(target=loop, name="pdf-annotator-cleanup", daemon=True)
+    thread.start()
+    app.extensions["cleanup_stop"] = stop
+    return thread

--- a/src/pdf_annotator/services/data_manager.py
+++ b/src/pdf_annotator/services/data_manager.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import DatabaseManager, get_db
 from pdf_annotator.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -37,10 +37,10 @@ class DataManager:
 
         Args:
             upload_folder: Path to uploads directory
-            db: DatabaseManager instance (uses singleton if not provided)
+            db: DatabaseManager instance (defaults to the app's instance)
         """
         self.upload_folder = Path(upload_folder)
-        self.db = db or DatabaseManager()
+        self.db = db or get_db()
 
     def export_data(
         self, doc_ids: list[str] | None = None, output_path: Path | None = None
@@ -200,7 +200,9 @@ class DataManager:
                 original_doc_id = doc_data.get("id")
                 doc_id = str(uuid4())
 
-                logger.debug("[Import] Doc #%d: %s → %s", doc_idx, original_doc_id, doc_id)
+                logger.debug(
+                    "[Import] Doc #%d: %s → %s", doc_idx, original_doc_id, doc_id
+                )
 
                 # Extract PDF file - try original doc_id first, then new doc_id
                 pdf_content = None
@@ -215,7 +217,10 @@ class DataManager:
                         pdf_content = None
 
                 if pdf_content is None:
-                    logger.debug("[Import] Skipped doc %s: PDF not found in archive", original_doc_id)
+                    logger.debug(
+                        "[Import] Skipped doc %s: PDF not found in archive",
+                        original_doc_id,
+                    )
                     stats["documents_skipped"] += 1
                     continue
 
@@ -223,14 +228,21 @@ class DataManager:
                     pdf_dest = self.upload_folder / f"{doc_id}.pdf"
 
                     # Ensure destination is safe (no path traversal)
-                    if not pdf_dest.resolve().is_relative_to(self.upload_folder.resolve()):
-                        logger.warning("[Import] Path traversal blocked for doc %s", original_doc_id)
+                    if not pdf_dest.resolve().is_relative_to(
+                        self.upload_folder.resolve()
+                    ):
+                        logger.warning(
+                            "[Import] Path traversal blocked for doc %s",
+                            original_doc_id,
+                        )
                         stats["documents_skipped"] += 1
                         continue
 
                     pdf_dest.write_bytes(pdf_content)
                 except OSError as e:
-                    logger.warning("[Import] File write error for doc %s: %s", original_doc_id, e)
+                    logger.warning(
+                        "[Import] File write error for doc %s: %s", original_doc_id, e
+                    )
                     stats["documents_skipped"] += 1
                     continue
 

--- a/src/pdf_annotator/services/jobs.py
+++ b/src/pdf_annotator/services/jobs.py
@@ -1,0 +1,88 @@
+"""
+In-process background jobs for long-running work (OCR, PDF export).
+
+One worker thread per process runs jobs off the request path; status
+lives in the shared SQLite jobs table and artifacts on the shared
+filesystem, so with multiple Gunicorn workers any worker can answer a
+poll for a job that another worker is running. No broker or external
+queue is needed, and the same code path serves the single-process
+desktop app.
+"""
+
+import json
+import threading
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# A job stuck in pending/running longer than this is considered orphaned
+# (killed worker, hung subprocess) and flipped to error by the cleanup
+# pass. Must exceed OCR_TIMEOUT_SECONDS with margin.
+JOB_STALE_SECONDS = 900
+
+# Terminal job rows (and their artifacts) are removed after this age.
+FINISHED_JOB_RETENTION_SECONDS = 24 * 3600
+
+# The runner returns a result dict; the "result_path" key is persisted to
+# the jobs.result_path column, the rest to result_json.
+Runner = Callable[[], dict[str, Any] | None]
+
+_executor: ThreadPoolExecutor | None = None
+_executor_lock = threading.Lock()
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    global _executor
+    with _executor_lock:
+        if _executor is None:
+            # One job at a time per process: OCR and 300-DPI export are
+            # CPU-heavy (ocrmypdf spawns its own process pool); requests
+            # keep being served on the other threads.
+            _executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="pdf-annotator-job"
+            )
+        return _executor
+
+
+def submit_job(
+    db: DatabaseManager,
+    job_type: str,
+    doc_id: str,
+    user_id: str,
+    runner: Runner,
+) -> str:
+    """
+    Insert a job row and execute `runner` on the background thread.
+
+    The runner must not touch current_app/request/current_user — capture
+    everything it needs (the db instance, file paths, config values) in
+    the closure at submit time.
+    """
+    job_id = db.create_job(job_type, doc_id, user_id)
+    _get_executor().submit(_run_job, db, job_id, runner)
+    logger.info("Submitted %s job %s for document %s", job_type, job_id, doc_id)
+    return job_id
+
+
+def _run_job(db: DatabaseManager, job_id: str, runner: Runner) -> None:
+    db.mark_job_running(job_id)
+    try:
+        result = runner() or {}
+    except Exception as e:
+        logger.error("Background job %s failed: %s", job_id, e, exc_info=True)
+        db.finish_job(job_id, "error", error=str(e))
+        return
+
+    result_path = result.pop("result_path", None)
+    db.finish_job(
+        job_id,
+        "done",
+        result_path=result_path,
+        result_json=json.dumps(result) if result else None,
+    )
+    logger.info("Background job %s finished", job_id)

--- a/src/pdf_annotator/services/markdown_exporter.py
+++ b/src/pdf_annotator/services/markdown_exporter.py
@@ -44,7 +44,7 @@ def export_to_markdown(doc_id: str, output_path: Path, db: DatabaseManager) -> b
         bool: True if successful, False otherwise
 
     Example:
-        db = DatabaseManager()
+        db = get_db()
         success = export_to_markdown(
             "abc-123",
             Path("notes.md"),

--- a/src/pdf_annotator/services/pdf_generator.py
+++ b/src/pdf_annotator/services/pdf_generator.py
@@ -190,7 +190,7 @@ def create_annotated_pdf(
         bool: True if successful, False otherwise
 
     Example:
-        db = DatabaseManager()
+        db = get_db()
         success = create_annotated_pdf(
             "abc-123",
             Path("output_annotated.pdf"),

--- a/src/pdf_annotator/services/pdf_generator.py
+++ b/src/pdf_annotator/services/pdf_generator.py
@@ -171,6 +171,7 @@ def create_annotated_pdf(
     font_name: str = "courier",
     font_size: float = 9,
     font_color: tuple[float, float, float] = (0, 0.5, 0),
+    upload_folder: Path | None = None,
 ) -> bool:
     """
     Create annotated PDF with all notes from database.
@@ -185,6 +186,10 @@ def create_annotated_pdf(
         font_name: Font for annotations (default: "courier")
         font_size: Font size in points (default: 9)
         font_color: RGB color tuple (0-1 range, default: green)
+        upload_folder: Base folder the source PDF must live in (path
+            traversal check). Defaults to the app config's UPLOAD_FOLDER;
+            background-job callers must pass it explicitly because they
+            run outside the application context.
 
     Returns:
         bool: True if successful, False otherwise
@@ -214,7 +219,8 @@ def create_annotated_pdf(
         original_path = Path(doc_info["file_path"])
 
         # Validate path to prevent path traversal attacks
-        upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
+        if upload_folder is None:
+            upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
         is_valid, error_msg = validate_file_path(original_path, upload_folder)
         if not is_valid:
             logger.error(f"Path traversal attempt blocked: {original_path}")

--- a/src/pdf_annotator/services/pdf_processor.py
+++ b/src/pdf_annotator/services/pdf_processor.py
@@ -4,14 +4,24 @@ PDF Processing module for PDF Annotator.
 Handles PDF rendering and validation using PyMuPDF (fitz).
 """
 
-from functools import lru_cache
 from pathlib import Path
 
 import fitz  # PyMuPDF
+from flask import current_app, has_app_context
 
+from pdf_annotator.services import render_cache
 from pdf_annotator.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _cache_dir() -> Path | None:
+    """The configured render cache directory, or None outside app context."""
+    if has_app_context():
+        folder = current_app.config.get("RENDER_CACHE_FOLDER")
+        if folder:
+            return Path(folder)
+    return None
 
 
 def validate_pdf(file_path: Path) -> bool:
@@ -95,13 +105,8 @@ def get_page_dimensions(file_path: Path, page_num: int) -> tuple[float, float]:
         raise
 
 
-@lru_cache(maxsize=50)
-def _render_page_cached(file_path: str, page_num: int, dpi: int) -> bytes:
-    """
-    Internal cached page rendering. Raises on failure so errors are never cached.
-
-    File path must be a string (not Path) for LRU cache compatibility.
-    """
+def _render_page(file_path: str, page_num: int, dpi: int) -> bytes:
+    """Internal page rendering. Raises on failure so errors are never cached."""
     logger.debug("Rendering page %d from %s", page_num, Path(file_path).name)
     doc = fitz.open(file_path)
 
@@ -133,8 +138,11 @@ def render_page_to_image(file_path: str, page_num: int, dpi: int = 300) -> bytes
     """
     Render PDF page to PNG image.
 
-    Wraps the cached internal renderer. Returns None on error instead of raising,
-    so callers do not need to handle exceptions.
+    Serves from the shared disk cache when an app context provides
+    RENDER_CACHE_FOLDER (entries are keyed by the PDF's mtime/size, so a
+    modified file is re-rendered automatically in every worker). Returns
+    None on error instead of raising, so callers do not need to handle
+    exceptions.
 
     Args:
         file_path: Path to PDF file (as string)
@@ -151,36 +159,32 @@ def render_page_to_image(file_path: str, page_num: int, dpi: int = 300) -> bytes
                 f.write(image_bytes)
     """
     try:
-        return _render_page_cached(file_path, page_num, dpi)
+        cache_dir = _cache_dir()
+        if cache_dir is not None:
+            return render_cache.get_or_render_page(
+                cache_dir,
+                Path(file_path),
+                page_num,
+                dpi,
+                lambda: _render_page(file_path, page_num, dpi),
+            )
+        return _render_page(file_path, page_num, dpi)
     except Exception as e:
         logger.error("Failed to render page %d from %s: %s", page_num, file_path, e)
         return None
 
 
-def clear_render_cache() -> None:
-    """
-    Clear the LRU cache for rendered pages.
-
-    Useful for freeing memory or when PDF files are updated.
-
-    Example:
-        clear_render_cache()
-        logger.info("Render cache cleared")
-    """
-    _render_page_cached.cache_clear()
-    logger.info("PDF render cache cleared")
-
-
-@lru_cache(maxsize=50)
 def get_page_text_layout(file_path: str, page_num: int) -> dict:
     """
     Extract word-level text with bounding boxes for a PDF page.
 
     Used to build a selectable/copyable text overlay on top of the raster
     page image. Coordinates are in PDF points, matching get_page_dimensions.
+    Served from the shared disk cache when an app context provides
+    RENDER_CACHE_FOLDER; extraction errors are never cached.
 
     Args:
-        file_path: Path to PDF file (as string, for LRU cache compatibility)
+        file_path: Path to PDF file (as string)
         page_num: Page number (1-indexed)
 
     Raises:
@@ -190,6 +194,19 @@ def get_page_text_layout(file_path: str, page_num: int) -> dict:
         dict with page_width, page_height (points) and lines, each a list
         of words with text and x0/y0/x1/y1 bounding box in points.
     """
+    cache_dir = _cache_dir()
+    if cache_dir is not None:
+        return render_cache.get_or_load_layout(
+            cache_dir,
+            Path(file_path),
+            page_num,
+            lambda: _extract_text_layout(file_path, page_num),
+        )
+    return _extract_text_layout(file_path, page_num)
+
+
+def _extract_text_layout(file_path: str, page_num: int) -> dict:
+    """Internal text-layout extraction. Raises on invalid pages."""
     doc = fitz.open(file_path)
     try:
         if page_num < 1 or page_num > len(doc):
@@ -234,35 +251,3 @@ def get_page_text_layout(file_path: str, page_num: int) -> dict:
         }
     finally:
         doc.close()
-
-
-def clear_text_layout_cache() -> None:
-    """
-    Clear the LRU cache for extracted text layouts.
-
-    Must be called alongside clear_render_cache() whenever a PDF's content
-    changes (replace/append/delete page), otherwise stale word/bbox data
-    could be served after the image cache has already been invalidated.
-    """
-    get_page_text_layout.cache_clear()
-    logger.info("PDF text layout cache cleared")
-
-
-def get_cache_info() -> dict:
-    """
-    Get information about the render cache.
-
-    Returns:
-        dict: Cache statistics (hits, misses, size, maxsize)
-
-    Example:
-        info = get_cache_info()
-        print(f"Cache hits: {info['hits']}, misses: {info['misses']}")
-    """
-    cache_info = _render_page_cached.cache_info()
-    return {
-        "hits": cache_info.hits,
-        "misses": cache_info.misses,
-        "size": cache_info.currsize,
-        "maxsize": cache_info.maxsize,
-    }

--- a/src/pdf_annotator/services/render_cache.py
+++ b/src/pdf_annotator/services/render_cache.py
@@ -1,0 +1,126 @@
+"""
+Disk-based cache for rendered page images and text layouts.
+
+Entries are keyed by the PDF's content identity (resolved path + mtime_ns
++ size). Every mutation in this app (replace, append, OCR, delete page)
+rewrites the PDF file, so the key changes and all workers automatically
+stop hitting stale entries — no cross-process invalidation signal needed,
+unlike the per-process lru_cache this replaces. Old entries are reclaimed
+by prune() (run by the cleanup thread), not by explicit invalidation.
+"""
+
+import hashlib
+import json
+import os
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from pdf_annotator.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _doc_dir(cache_dir: Path, file_path: Path) -> Path:
+    stat = file_path.stat()
+    raw = f"{file_path.resolve()}|{stat.st_mtime_ns}|{stat.st_size}"
+    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()
+    return cache_dir / digest[:2] / digest
+
+
+def _atomic_write(target: Path, data: bytes) -> None:
+    # Unique temp name per writer: concurrent workers may render the same
+    # page twice (harmless) but never serve a torn file.
+    tmp = target.with_name(f"{target.name}.tmp-{os.getpid()}-{uuid.uuid4().hex[:8]}")
+    tmp.write_bytes(data)
+    os.replace(tmp, target)
+
+
+def _get_or_create(target: Path, produce: Callable[[], bytes]) -> bytes:
+    try:
+        data = target.read_bytes()
+        # Refresh mtime so prune() evicts least-recently-used entries.
+        os.utime(target)
+        return data
+    except FileNotFoundError:
+        pass
+    data = produce()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write(target, data)
+    return data
+
+
+def get_or_render_page(
+    cache_dir: Path,
+    file_path: Path,
+    page_num: int,
+    dpi: int,
+    render: Callable[[], bytes],
+) -> bytes:
+    """Return the cached PNG for a page, rendering and storing on miss."""
+    target = _doc_dir(cache_dir, file_path) / f"page{page_num}@{dpi}.png"
+    return _get_or_create(target, render)
+
+
+def get_or_load_layout(
+    cache_dir: Path,
+    file_path: Path,
+    page_num: int,
+    extract: Callable[[], dict[str, Any]],
+) -> dict[str, Any]:
+    """Return the cached text layout for a page, extracting on miss."""
+    target = _doc_dir(cache_dir, file_path) / f"page{page_num}.layout.json"
+
+    def produce() -> bytes:
+        return json.dumps(extract()).encode("utf-8")
+
+    return dict(json.loads(_get_or_create(target, produce).decode("utf-8")))
+
+
+def prune(cache_dir: Path, max_bytes: int) -> int:
+    """
+    Delete least-recently-used cache entries until the cache fits max_bytes.
+
+    Also removes leftover temp files and empty directories. Returns the
+    number of bytes freed. Safe to run concurrently with readers/writers —
+    a pruned entry is simply re-rendered on the next request.
+    """
+    if not cache_dir.is_dir():
+        return 0
+
+    entries: list[tuple[float, int, Path]] = []
+    total = 0
+    for path in cache_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        if ".tmp-" in path.name:
+            path.unlink(missing_ok=True)
+            continue
+        entries.append((stat.st_mtime, stat.st_size, path))
+        total += stat.st_size
+
+    freed = 0
+    if total > max_bytes:
+        entries.sort()  # oldest first
+        for _mtime, size, path in entries:
+            if total - freed <= max_bytes:
+                break
+            path.unlink(missing_ok=True)
+            freed += size
+        logger.info("Render cache pruned: %d bytes freed", freed)
+
+    # Drop directories emptied by pruning (deepest first).
+    for directory in sorted(
+        (p for p in cache_dir.rglob("*") if p.is_dir()), reverse=True
+    ):
+        try:
+            directory.rmdir()
+        except OSError:
+            pass
+
+    return freed

--- a/src/pdf_annotator/static/js/documents.js
+++ b/src/pdf_annotator/static/js/documents.js
@@ -83,7 +83,7 @@
         btn.addEventListener('click', function(event) {
             event.preventDefault();
             const docId = this.dataset.docId;
-            downloadFile(`/export/pdf/${docId}`, 'POST', this);
+            downloadExportedPdf(docId, this);
         });
     });
 
@@ -105,6 +105,36 @@
             downloadFile(`/export/original/${docId}`, 'GET', this);
         });
     });
+
+    // Annotated-PDF export runs as a background job: POST returns 202 with
+    // a job_id, we poll it (jobs.js) and fetch the artifact when done.
+    function downloadExportedPdf(docId, btn) {
+        const originalText = btn ? btn.textContent : null;
+        if (btn) { btn.disabled = true; btn.textContent = '...'; }
+        fetch(`/export/pdf/${docId}`, {
+            method: 'POST',
+            headers: { 'X-CSRFToken': csrfToken },
+        })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().catch(() => ({})).then(data => {
+                        throw new Error(data.error || 'Export fehlgeschlagen');
+                    });
+                }
+                return response.json();
+            })
+            .then(data => pollJob(data.job_id).then(() => data.job_id))
+            .then(jobId => {
+                downloadFile(`/export/download/${jobId}`, 'GET', null);
+            })
+            .catch(error => {
+                console.error('Export error:', error);
+                showToast('Fehler beim Export: ' + error.message, 'error');
+            })
+            .finally(() => {
+                if (btn) { btn.disabled = false; btn.textContent = originalText; }
+            });
+    }
 
     function downloadFile(url, method, btn) {
         const originalText = btn ? btn.textContent : null;

--- a/src/pdf_annotator/static/js/jobs.js
+++ b/src/pdf_annotator/static/js/jobs.js
@@ -1,0 +1,38 @@
+// Shared helper for polling background jobs (OCR, PDF export).
+//
+// pollJob(jobId) resolves with the job's status JSON once the job is
+// "done", and rejects with an Error when the job reports "error", the
+// status request fails, or the client-side timeout is reached (safety
+// net in case the server lost the job, e.g. across a restart).
+function pollJob(jobId, options) {
+    const intervalMs = (options && options.intervalMs) || 2000;
+    const timeoutMs = (options && options.timeoutMs) || 15 * 60 * 1000;
+    const deadline = Date.now() + timeoutMs;
+
+    return new Promise((resolve, reject) => {
+        function check() {
+            fetch(`/viewer/api/jobs/${jobId}`)
+                .then(response => {
+                    if (!response.ok) {
+                        return response.json().catch(() => ({})).then(data => {
+                            throw new Error(data.error || 'Statusabfrage fehlgeschlagen');
+                        });
+                    }
+                    return response.json();
+                })
+                .then(job => {
+                    if (job.status === 'done') {
+                        resolve(job);
+                    } else if (job.status === 'error') {
+                        reject(new Error(job.error || 'Vorgang fehlgeschlagen'));
+                    } else if (Date.now() > deadline) {
+                        reject(new Error('Zeitüberschreitung – bitte später erneut versuchen'));
+                    } else {
+                        setTimeout(check, intervalMs);
+                    }
+                })
+                .catch(reject);
+        }
+        check();
+    });
+}

--- a/src/pdf_annotator/static/js/viewer.js
+++ b/src/pdf_annotator/static/js/viewer.js
@@ -1016,6 +1016,7 @@
                     }
                     return response.json();
                 })
+                .then(data => pollJob(data.job_id))
                 .then(() => {
                     showToast('Texterkennung abgeschlossen.', 'success');
                     noTextHint.style.display = 'none';

--- a/src/pdf_annotator/static/js/viewer.js
+++ b/src/pdf_annotator/static/js/viewer.js
@@ -899,12 +899,22 @@
         saveNote(true); // Immediate save
     });
 
-    // Save before page unload using sendBeacon for reliability
-    window.addEventListener('beforeunload', function(e) {
+    // Save before page unload. fetch with keepalive survives the page
+    // teardown like sendBeacon, but can carry the CSRF header sendBeacon
+    // cannot. pagehide fires more reliably than beforeunload (bfcache).
+    window.addEventListener('pagehide', function() {
         if (noteField.value.trim() !== '') {
             const saveUrl = `/viewer/api/annotation/${docId}/${currentPage}`;
             const data = JSON.stringify({ note_text: noteField.value });
-            navigator.sendBeacon(saveUrl, new Blob([data], { type: 'application/json' }));
+            fetch(saveUrl, {
+                method: 'POST',
+                keepalive: true,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken
+                },
+                body: data
+            });
         }
     });
 

--- a/src/pdf_annotator/templates/auth/login.html
+++ b/src/pdf_annotator/templates/auth/login.html
@@ -111,9 +111,11 @@
             <button type="submit" class="btn-login">Einloggen</button>
         </form>
 
+        {% if config.REGISTRATION_ENABLED %}
         <div class="auth-links">
             Noch kein Konto? <a href="{{ url_for('auth.register') }}">Jetzt registrieren</a>
         </div>
+        {% endif %}
     </div>
 </body>
 </html>

--- a/src/pdf_annotator/templates/auth/register.html
+++ b/src/pdf_annotator/templates/auth/register.html
@@ -124,6 +124,13 @@
                 <input type="password" id="password_confirm" name="password_confirm" minlength="8" required>
             </div>
 
+            {% if config.REGISTRATION_INVITE_CODE %}
+            <div class="form-group">
+                <label for="invite_code">Einladungscode</label>
+                <input type="text" id="invite_code" name="invite_code" required>
+            </div>
+            {% endif %}
+
             <button type="submit" class="btn-register">Registrieren</button>
         </form>
 

--- a/src/pdf_annotator/templates/documents.html
+++ b/src/pdf_annotator/templates/documents.html
@@ -96,5 +96,6 @@
 {% block extra_js %}
 <!-- Hidden file input for PDF replacement -->
 <input type="file" id="replace-pdf-file-input" accept=".pdf" style="display: none;">
+<script src="{{ url_for('static', filename='js/jobs.js') }}"></script>
 <script src="{{ url_for('static', filename='js/documents.js') }}"></script>
 {% endblock %}

--- a/src/pdf_annotator/templates/viewer.html
+++ b/src/pdf_annotator/templates/viewer.html
@@ -176,5 +176,6 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="{{ url_for('static', filename='js/jobs.js') }}"></script>
 <script src="{{ url_for('static', filename='js/viewer.js') }}"></script>
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,20 @@ def client(app):
 
 
 @pytest.fixture()
+def inline_jobs(monkeypatch):
+    """Run background jobs synchronously so tests can poll immediately
+    after submitting and see a terminal status."""
+
+    class InlineExecutor:
+        def submit(self, fn, *args, **kwargs):
+            fn(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "pdf_annotator.services.jobs._get_executor", lambda: InlineExecutor()
+    )
+
+
+@pytest.fixture()
 def db(tmp_path):
     """DatabaseManager with file-based temp database and default test user."""
     db_path = tmp_path / "test.db"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ def app(tmp_path):
             "DATABASE_PATH": db_path,
             "UPLOAD_FOLDER": upload_folder,
             "EXPORT_FOLDER": export_folder,
+            "RENDER_CACHE_FOLDER": tmp_path / "cache",
             # Isolate tests from any real AI provider config picked up
             # from a developer's local .env (repo-root or data-dir) —
             # tests that need specific values set them explicitly.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,14 +15,6 @@ from pdf_annotator.app import create_app
 from pdf_annotator.models.database import DatabaseManager
 
 
-@pytest.fixture(autouse=True)
-def reset_db_singleton():
-    """Reset DatabaseManager singleton between tests."""
-    yield
-    DatabaseManager._instance = None
-    DatabaseManager._db_path = None
-
-
 @pytest.fixture()
 def app(tmp_path):
     """Create Flask app configured for testing."""
@@ -32,30 +24,22 @@ def app(tmp_path):
     export_folder.mkdir()
     db_path = tmp_path / "test.db"
 
-    # Reset singleton before creating app so it picks up our db_path
-    DatabaseManager._instance = None
-    DatabaseManager._db_path = None
-
-    app = create_app("testing")
-    app.config["UPLOAD_FOLDER"] = upload_folder
-    app.config["EXPORT_FOLDER"] = export_folder
-    app.config["DATABASE_PATH"] = db_path
-
-    # Isolate tests from any real AI provider config picked up from a
-    # developer's local .env (repo-root or data-dir) — tests that need
-    # specific values set them explicitly.
-    app.config["AI_PROVIDER"] = None
-    app.config["AI_MODEL"] = None
-    app.config["ANTHROPIC_API_KEY"] = None
-    app.config["OPENAI_API_KEY"] = None
-    app.config["OPENAI_BASE_URL"] = None
-
-    # Re-init DB with the file-based path (create_app used :memory:
-    # which doesn't work across connections)
-    DatabaseManager._instance = None
-    DatabaseManager._db_path = None
-    db = DatabaseManager(db_path)
-    db.init_db()
+    app = create_app(
+        "testing",
+        config_overrides={
+            "DATABASE_PATH": db_path,
+            "UPLOAD_FOLDER": upload_folder,
+            "EXPORT_FOLDER": export_folder,
+            # Isolate tests from any real AI provider config picked up
+            # from a developer's local .env (repo-root or data-dir) —
+            # tests that need specific values set them explicitly.
+            "AI_PROVIDER": None,
+            "AI_MODEL": None,
+            "ANTHROPIC_API_KEY": None,
+            "OPENAI_API_KEY": None,
+            "OPENAI_BASE_URL": None,
+        },
+    )
 
     yield app
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,7 @@ Tests for authentication routes, focused on the change-password feature.
 
 from werkzeug.security import check_password_hash
 
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import get_db
 
 
 class TestChangePassword:
@@ -31,9 +31,8 @@ class TestChangePassword:
         assert response.status_code == 200
         assert "erfolgreich" in response.get_data(as_text=True)
 
-        db = DatabaseManager()
         with app.app_context():
-            user_data = db.get_user_by_id(user)
+            user_data = get_db().get_user_by_id(user)
         assert check_password_hash(user_data["password_hash"], "newpassword123")
 
     def test_wrong_current_password_rejected(self, app, logged_in_client, user):
@@ -47,9 +46,8 @@ class TestChangePassword:
         )
         assert response.status_code == 401
 
-        db = DatabaseManager()
         with app.app_context():
-            user_data = db.get_user_by_id(user)
+            user_data = get_db().get_user_by_id(user)
         assert check_password_hash(user_data["password_hash"], "testpassword")
 
     def test_too_short_new_password_rejected(self, app, logged_in_client):

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,104 @@
+"""
+Tests for the periodic cleanup service.
+"""
+
+import os
+import time
+
+from pdf_annotator.services import cleanup, jobs
+
+
+def _aged_file(folder, name: str, age_seconds: int):
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / name
+    path.write_bytes(b"inhalt")
+    stamp = time.time() - age_seconds
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+class TestRunCleanupOnce:
+    def test_old_exports_deleted_fresh_kept(self, db, tmp_path):
+        exports = tmp_path / "exports"
+        old = _aged_file(exports, "alt.pdf", cleanup.EXPORT_MAX_AGE_SECONDS + 60)
+        fresh = _aged_file(exports, "neu.pdf", 10)
+
+        cleanup.run_cleanup_once(db, exports, tmp_path / "cache", 10**9)
+
+        assert not old.exists()
+        assert fresh.exists()
+
+    def test_stale_job_flipped_and_expired_artifact_removed(
+        self, db, tmp_path, uploaded_pdf, user
+    ):
+        # A running job orphaned long ago...
+        stale_id = db.create_job("ocr", uploaded_pdf, user)
+        db.mark_job_running(stale_id)
+        # ...and an old finished export job with an artifact on disk.
+        artifact = _aged_file(tmp_path / "exports", "fertig.pdf", 10)
+        done_id = db.create_job("export_pdf", uploaded_pdf, user)
+        db.finish_job(done_id, "done", result_path=str(artifact))
+        with db.get_connection() as conn:
+            conn.execute(
+                "UPDATE jobs SET created_at = datetime('now', '-2 days'),"
+                " finished_at = datetime('now', '-2 days')"
+            )
+
+        cleanup.run_cleanup_once(db, tmp_path / "exports", tmp_path / "cache", 10**9)
+
+        assert db.get_job(stale_id)["status"] == "error"
+        assert db.get_job(done_id) is None
+        assert not artifact.exists()
+
+    def test_cache_pruned_to_budget(self, db, tmp_path):
+        cache = tmp_path / "cache"
+        entry = _aged_file(cache / "aa" / "aabb", "page1@72.png", 3600)
+
+        cleanup.run_cleanup_once(db, tmp_path / "exports", cache, 0)
+
+        assert not entry.exists()
+
+
+class TestCleanupThread:
+    def test_not_started_in_testing_config(self, app):
+        assert "cleanup_stop" not in app.extensions
+
+    def test_thread_runs_and_stops(self, app, tmp_path, monkeypatch):
+        monkeypatch.setattr(cleanup, "STARTUP_DELAY_SECONDS", 0)
+        monkeypatch.setattr(cleanup, "CLEANUP_INTERVAL_SECONDS", 0.05)
+        monkeypatch.setattr(cleanup, "JITTER_SECONDS", 0)
+
+        exports = tmp_path / "exports"
+        old = _aged_file(exports, "alt.pdf", cleanup.EXPORT_MAX_AGE_SECONDS + 60)
+        app.config["EXPORT_FOLDER"] = exports
+
+        thread = cleanup.start_cleanup_thread(app)
+        try:
+            deadline = time.time() + 5
+            while old.exists() and time.time() < deadline:
+                time.sleep(0.02)
+            assert not old.exists()
+        finally:
+            app.extensions["cleanup_stop"].set()
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+    def test_lock_is_exclusive(self, tmp_path):
+        lock_path = tmp_path / "cleanup.lock"
+        first = cleanup._try_lock(lock_path)
+        assert first is not None
+
+        second = cleanup._try_lock(lock_path)
+        assert second is None
+
+        first.close()
+        third = cleanup._try_lock(lock_path)
+        assert third is not None
+        third.close()
+
+
+class TestStaleConstants:
+    def test_stale_threshold_exceeds_ocr_timeout(self):
+        from pdf_annotator.services.ocr import OCR_TIMEOUT_SECONDS
+
+        assert jobs.JOB_STALE_SECONDS > OCR_TIMEOUT_SECONDS

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,9 @@ import stat
 
 import pytest
 from flask import Flask
+from werkzeug.middleware.proxy_fix import ProxyFix
 
+from pdf_annotator.app import create_app
 from pdf_annotator.config import ProductionConfig, _load_or_create_secret_key
 
 
@@ -107,3 +109,48 @@ class TestSessionCookieFlags:
         assert "SameSite=Lax" in session_cookies[0]
         # Plain http (desktop/dev) must not mark the cookie Secure
         assert "Secure" not in session_cookies[0]
+
+
+class TestBehindProxy:
+    """Tests for the PDF_ANNOTATOR_BEHIND_PROXY reverse-proxy switch."""
+
+    def test_flag_enables_proxyfix_secure_cookies_and_hsts(self, monkeypatch):
+        monkeypatch.setenv("PDF_ANNOTATOR_BEHIND_PROXY", "1")
+        app = create_app("testing")
+
+        assert isinstance(app.wsgi_app, ProxyFix)
+        assert app.config["SESSION_COOKIE_SECURE"] is True
+        assert app.config["REMEMBER_COOKIE_SECURE"] is True
+        assert app.config["PREFERRED_URL_SCHEME"] == "https"
+
+        response = app.test_client().get("/health")
+        assert response.headers["Strict-Transport-Security"].startswith("max-age=")
+
+    def test_forwarded_proto_reaches_request_scheme(self, monkeypatch):
+        monkeypatch.setenv("PDF_ANNOTATOR_BEHIND_PROXY", "1")
+        app = create_app("testing")
+
+        seen: dict[str, str] = {}
+
+        @app.route("/_test_scheme")
+        def _test_scheme() -> str:
+            from flask import request
+
+            seen["scheme"] = request.scheme
+            seen["remote_addr"] = request.remote_addr or ""
+            return "ok"
+
+        app.test_client().get(
+            "/_test_scheme",
+            headers={
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-For": "203.0.113.7",
+            },
+        )
+        assert seen["scheme"] == "https"
+        assert seen["remote_addr"] == "203.0.113.7"
+
+    def test_without_flag_no_proxyfix_and_no_hsts(self, client, app):
+        assert not isinstance(app.wsgi_app, ProxyFix)
+        response = client.get("/health")
+        assert "Strict-Transport-Security" not in response.headers

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,6 +111,21 @@ class TestSessionCookieFlags:
         assert "Secure" not in session_cookies[0]
 
 
+class TestCsrfCoverage:
+    """The annotation save endpoint is no longer CSRF-exempt."""
+
+    def test_save_annotation_requires_csrf_token(
+        self, app, logged_in_client, uploaded_pdf
+    ):
+        app.config["WTF_CSRF_ENABLED"] = True
+
+        response = logged_in_client.post(
+            f"/viewer/api/annotation/{uploaded_pdf}/1",
+            json={"note_text": "ohne Token"},
+        )
+        assert response.status_code == 400
+
+
 class TestBehindProxy:
     """Tests for the PDF_ANNOTATOR_BEHIND_PROXY reverse-proxy switch."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,109 @@
+"""
+Tests for configuration: persisted SECRET_KEY and session cookie flags.
+"""
+
+import os
+import stat
+
+import pytest
+from flask import Flask
+
+from pdf_annotator.config import ProductionConfig, _load_or_create_secret_key
+
+
+class TestLoadOrCreateSecretKey:
+    """Tests for the persistent secret key helper."""
+
+    def test_creates_key_file_with_restrictive_permissions(self, tmp_path):
+        key = _load_or_create_secret_key(tmp_path)
+
+        key_file = tmp_path / "secret_key"
+        assert key_file.exists()
+        assert key_file.read_text().strip() == key
+        assert len(key) == 64  # token_hex(32)
+        mode = stat.S_IMODE(key_file.stat().st_mode)
+        assert mode == 0o600
+
+    def test_reuses_existing_key(self, tmp_path):
+        first = _load_or_create_secret_key(tmp_path)
+        second = _load_or_create_secret_key(tmp_path)
+        assert first == second
+
+    def test_reads_key_written_externally(self, tmp_path):
+        (tmp_path / "secret_key").write_text("my-external-key\n")
+        assert _load_or_create_secret_key(tmp_path) == "my-external-key"
+
+    def test_creates_missing_data_dir(self, tmp_path):
+        target = tmp_path / "nested" / "data"
+        key = _load_or_create_secret_key(target)
+        assert (target / "secret_key").read_text().strip() == key
+
+
+def _make_production_app(tmp_path, monkeypatch) -> Flask:
+    """Flask app with ProductionConfig, redirected to tmp paths."""
+    monkeypatch.setattr(ProductionConfig, "DATA_DIR", tmp_path)
+    app = Flask(__name__)
+    app.config.from_object(ProductionConfig)
+    app.config.update(
+        UPLOAD_FOLDER=tmp_path / "uploads",
+        EXPORT_FOLDER=tmp_path / "exports",
+        DATABASE_PATH=tmp_path / "annotations.db",
+        AI_PROVIDER=None,
+    )
+    return app
+
+
+class TestProductionSecretKey:
+    """Tests for ProductionConfig.init_app SECRET_KEY handling."""
+
+    def test_env_key_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SECRET_KEY", "from-environment")
+        monkeypatch.delenv("PDF_ANNOTATOR_BEHIND_PROXY", raising=False)
+        app = _make_production_app(tmp_path, monkeypatch)
+        app.config["SECRET_KEY"] = os.environ["SECRET_KEY"]
+
+        ProductionConfig.init_app(app)
+
+        assert app.config["SECRET_KEY"] == "from-environment"
+        assert not (tmp_path / "secret_key").exists()
+
+    def test_missing_key_behind_proxy_fails_hard(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.setenv("PDF_ANNOTATOR_BEHIND_PROXY", "1")
+        app = _make_production_app(tmp_path, monkeypatch)
+
+        with pytest.raises(RuntimeError, match="SECRET_KEY"):
+            ProductionConfig.init_app(app)
+
+    def test_missing_key_without_proxy_persists_key(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.delenv("PDF_ANNOTATOR_BEHIND_PROXY", raising=False)
+        app = _make_production_app(tmp_path, monkeypatch)
+
+        ProductionConfig.init_app(app)
+
+        persisted = (tmp_path / "secret_key").read_text().strip()
+        assert app.config["SECRET_KEY"] == persisted
+
+        # A second app (e.g. another Gunicorn worker) gets the same key
+        other = _make_production_app(tmp_path, monkeypatch)
+        ProductionConfig.init_app(other)
+        assert other.config["SECRET_KEY"] == persisted
+
+
+class TestSessionCookieFlags:
+    """Tests for hardened session cookie attributes."""
+
+    def test_login_cookie_is_httponly_and_lax(self, client, user):
+        response = client.post(
+            "/auth/login",
+            data={"username": "testuser", "password": "testpassword"},
+        )
+
+        cookies = response.headers.getlist("Set-Cookie")
+        session_cookies = [c for c in cookies if c.startswith("session=")]
+        assert session_cookies, "login did not set a session cookie"
+        assert "HttpOnly" in session_cookies[0]
+        assert "SameSite=Lax" in session_cookies[0]
+        # Plain http (desktop/dev) must not mark the cookie Secure
+        assert "Secure" not in session_cookies[0]

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,63 @@
+"""
+Tests for content-negotiating error handlers and get_owned_document.
+"""
+
+import uuid
+
+UNKNOWN_ID = str(uuid.uuid4())
+
+
+class TestJsonErrors:
+    """API paths answer errors as JSON."""
+
+    def test_invalid_doc_id_returns_json_400(self, logged_in_client):
+        response = logged_in_client.get("/viewer/api/annotation/not-a-uuid/1")
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "Ungültige Dokument-ID"
+
+    def test_unknown_document_returns_json_404(self, logged_in_client):
+        response = logged_in_client.get(f"/viewer/api/annotation/{UNKNOWN_ID}/1")
+        assert response.status_code == 404
+        assert response.get_json()["error"] == "Dokument nicht gefunden"
+
+    def test_foreign_document_returns_json_403(self, client, uploaded_pdf, second_user):
+        login = client.post(
+            "/auth/login",
+            data={"username": "seconduser", "password": "secondpassword"},
+        )
+        assert login.status_code == 302
+
+        response = client.get(f"/viewer/api/annotation/{uploaded_pdf}/1")
+        assert response.status_code == 403
+        assert response.get_json()["error"] == "Nicht berechtigt"
+
+    def test_export_route_errors_as_json(self, logged_in_client):
+        response = logged_in_client.post(f"/export/pdf/{UNKNOWN_ID}")
+        assert response.status_code == 404
+        assert response.get_json()["error"] == "Dokument nicht gefunden"
+
+    def test_delete_route_errors_as_json(self, logged_in_client):
+        response = logged_in_client.delete("/delete/not-a-uuid")
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "Ungültige Dokument-ID"
+
+
+class TestHtmlErrors:
+    """Browser page requests get the HTML error page."""
+
+    def test_viewer_page_invalid_id_renders_html_400(self, logged_in_client):
+        response = logged_in_client.get("/viewer/not-a-uuid")
+        assert response.status_code == 400
+        assert "text/html" in response.content_type
+        assert "Ungültige Anfrage" in response.data.decode()
+
+    def test_viewer_page_unknown_doc_renders_html_404(self, logged_in_client):
+        response = logged_in_client.get(f"/viewer/{UNKNOWN_ID}")
+        assert response.status_code == 404
+        assert "text/html" in response.content_type
+        assert "Seite nicht gefunden" in response.data.decode()
+
+    def test_unknown_url_renders_html_404(self, logged_in_client):
+        response = logged_in_client.get("/gibt-es-nicht")
+        assert response.status_code == 404
+        assert "text/html" in response.content_type

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,149 @@
+"""
+Tests for the Flask-WTF auth forms via the HTTP routes.
+
+Asserts that status codes and German error messages match the previous
+hand-rolled validation exactly.
+"""
+
+
+def _register(client, **overrides):
+    data = {
+        "username": "neueruser",
+        "email": "neu@example.com",
+        "password": "geheimespasswort",
+        "password_confirm": "geheimespasswort",
+    }
+    data.update(overrides)
+    return client.post("/auth/register", data=data)
+
+
+class TestRegisterForm:
+    def test_missing_field_message_wins(self, client):
+        response = _register(client, email="")
+        assert response.status_code == 400
+        assert "Alle Felder erforderlich." in response.data.decode()
+
+    def test_missing_field_beats_other_errors(self, client):
+        # Short username AND missing email: presence error has priority,
+        # as in the previous implementation.
+        response = _register(client, username="ab", email="")
+        assert response.status_code == 400
+        assert "Alle Felder erforderlich." in response.data.decode()
+
+    def test_short_username(self, client):
+        response = _register(client, username="ab")
+        assert response.status_code == 400
+        assert (
+            "Benutzername muss zwischen 3 und 50 Zeichen lang sein."
+            in response.data.decode()
+        )
+
+    def test_short_password(self, client):
+        response = _register(client, password="kurz", password_confirm="kurz")
+        assert response.status_code == 400
+        assert "Passwort muss mindestens 8 Zeichen lang sein." in response.data.decode()
+
+    def test_password_mismatch(self, client):
+        response = _register(client, password_confirm="etwasanderes")
+        assert response.status_code == 400
+        assert "Passwörter stimmen nicht überein." in response.data.decode()
+
+    def test_invalid_email(self, client):
+        response = _register(client, email="keine-email")
+        assert response.status_code == 400
+        assert "Ungültige E-Mail-Adresse." in response.data.decode()
+
+    def test_duplicate_username(self, client, user):
+        response = _register(client, username="testuser")
+        assert response.status_code == 409
+        assert "Benutzername bereits vergeben." in response.data.decode()
+
+    def test_successful_registration_redirects(self, client):
+        response = _register(client)
+        assert response.status_code == 302
+
+    def test_username_is_stripped(self, client, db):
+        response = _register(client, username="  neueruser  ")
+        assert response.status_code == 302
+        assert db.get_user_by_username("neueruser") is not None
+
+
+class TestLoginForm:
+    def test_missing_credentials(self, client):
+        response = client.post("/auth/login", data={"username": "", "password": ""})
+        assert response.status_code == 400
+        assert "Benutzername und Passwort erforderlich." in response.data.decode()
+
+    def test_wrong_credentials(self, client, user):
+        response = client.post(
+            "/auth/login", data={"username": "testuser", "password": "falsch1234"}
+        )
+        assert response.status_code == 401
+        assert "Ungültige Anmeldedaten." in response.data.decode()
+
+    def test_successful_login_redirects(self, client, user):
+        response = client.post(
+            "/auth/login", data={"username": "testuser", "password": "testpassword"}
+        )
+        assert response.status_code == 302
+
+
+class TestChangePasswordForm:
+    def test_wrong_current_password_wins(self, logged_in_client):
+        # Wrong current password AND a too-short new password: the 401
+        # must win, matching the previous check order.
+        response = logged_in_client.post(
+            "/auth/change-password",
+            data={
+                "current_password": "falsch",
+                "new_password": "kurz",
+                "new_password_confirm": "kurz",
+            },
+        )
+        assert response.status_code == 401
+        assert "Aktuelles Passwort ist falsch." in response.data.decode()
+
+    def test_short_new_password(self, logged_in_client):
+        response = logged_in_client.post(
+            "/auth/change-password",
+            data={
+                "current_password": "testpassword",
+                "new_password": "kurz",
+                "new_password_confirm": "kurz",
+            },
+        )
+        assert response.status_code == 400
+        assert (
+            "Neues Passwort muss mindestens 8 Zeichen lang sein."
+            in response.data.decode()
+        )
+
+    def test_new_password_mismatch(self, logged_in_client):
+        response = logged_in_client.post(
+            "/auth/change-password",
+            data={
+                "current_password": "testpassword",
+                "new_password": "langesneues1",
+                "new_password_confirm": "langesneues2",
+            },
+        )
+        assert response.status_code == 400
+        assert "Neue Passwörter stimmen nicht überein." in response.data.decode()
+
+    def test_successful_change(self, logged_in_client, client):
+        response = logged_in_client.post(
+            "/auth/change-password",
+            data={
+                "current_password": "testpassword",
+                "new_password": "ganzneuespasswort",
+                "new_password_confirm": "ganzneuespasswort",
+            },
+        )
+        assert response.status_code == 200
+        assert "Passwort erfolgreich geändert." in response.data.decode()
+
+        login = client.post(
+            "/auth/login",
+            data={"username": "testuser", "password": "ganzneuespasswort"},
+        )
+        assert login.status_code == 302

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -68,6 +68,47 @@ class TestRegisterForm:
         assert db.get_user_by_username("neueruser") is not None
 
 
+class TestRegistrationGate:
+    def test_disabled_blocks_get_and_post(self, app, client, user):
+        app.config["REGISTRATION_ENABLED"] = False
+
+        assert client.get("/auth/register").status_code == 403
+        response = _register(client)
+        assert response.status_code == 403
+        assert "Die Registrierung ist deaktiviert." in response.data.decode()
+
+    def test_disabled_still_allows_first_user(self, app, client):
+        app.config["REGISTRATION_ENABLED"] = False
+
+        response = _register(client)
+        assert response.status_code == 302
+
+    def test_wrong_invite_code_rejected(self, app, client):
+        app.config["REGISTRATION_INVITE_CODE"] = "geheim123"
+
+        response = _register(client, invite_code="falsch")
+        assert response.status_code == 403
+        assert "Ungültiger Einladungscode." in response.data.decode()
+
+    def test_missing_invite_code_rejected(self, app, client):
+        app.config["REGISTRATION_INVITE_CODE"] = "geheim123"
+
+        response = _register(client)
+        assert response.status_code == 403
+
+    def test_correct_invite_code_accepted(self, app, client):
+        app.config["REGISTRATION_INVITE_CODE"] = "geheim123"
+
+        response = _register(client, invite_code="geheim123")
+        assert response.status_code == 302
+
+    def test_login_page_hides_register_link_when_disabled(self, app, client):
+        app.config["REGISTRATION_ENABLED"] = False
+
+        html = client.get("/auth/login").data.decode()
+        assert "Jetzt registrieren" not in html
+
+
 class TestLoginForm:
     def test_missing_credentials(self, client):
         response = client.post("/auth/login", data={"username": "", "password": ""})

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -52,6 +52,27 @@ class TestJobLifecycle:
 
         assert job["status"] == "done"
 
+    def test_export_job_runs_on_real_thread(self, logged_in_client, uploaded_pdf, db):
+        """Full export flow through the actual executor — regression test
+        for runners accidentally touching the application context (the
+        inline test executor runs inside the request and masks that)."""
+        response = logged_in_client.post(f"/export/pdf/{uploaded_pdf}")
+        assert response.status_code == 202
+        job_id = response.get_json()["job_id"]
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            job = db.get_job(job_id)
+            if job["status"] in ("done", "error"):
+                break
+            time.sleep(0.1)
+
+        assert job["status"] == "done", job["error"]
+
+        download = logged_in_client.get(f"/export/download/{job_id}")
+        assert download.status_code == 200
+        assert download.data[:5] == b"%PDF-"
+
 
 class TestJobStatusEndpoint:
     def test_unknown_job_404(self, logged_in_client):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,150 @@
+"""
+Tests for the background job service and job-related endpoints.
+"""
+
+import time
+import uuid
+
+from pdf_annotator.services import jobs
+from pdf_annotator.services.jobs import submit_job
+
+
+class TestJobLifecycle:
+    def test_successful_job_stores_result(self, app, db, uploaded_pdf, inline_jobs):
+        with app.app_context():
+            job_id = submit_job(
+                db,
+                "export_pdf",
+                uploaded_pdf,
+                db.test_user_id,
+                lambda: {"result_path": "/tmp/x.pdf", "filename": "x.pdf"},
+            )
+
+        job = db.get_job(job_id)
+        assert job["status"] == "done"
+        assert job["result_path"] == "/tmp/x.pdf"
+        assert "x.pdf" in job["result_json"]
+        assert job["started_at"] is not None
+        assert job["finished_at"] is not None
+
+    def test_failing_job_stores_error(self, app, db, uploaded_pdf, inline_jobs):
+        def boom() -> dict:
+            raise RuntimeError("kaputt")
+
+        with app.app_context():
+            job_id = submit_job(db, "ocr", uploaded_pdf, db.test_user_id, boom)
+
+        job = db.get_job(job_id)
+        assert job["status"] == "error"
+        assert job["error"] == "kaputt"
+
+    def test_real_thread_executes_job(self, app, db, uploaded_pdf):
+        """Smoke test through the actual ThreadPoolExecutor."""
+        with app.app_context():
+            job_id = submit_job(db, "ocr", uploaded_pdf, db.test_user_id, lambda: {})
+
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            job = db.get_job(job_id)
+            if job["status"] in ("done", "error"):
+                break
+            time.sleep(0.05)
+
+        assert job["status"] == "done"
+
+
+class TestJobStatusEndpoint:
+    def test_unknown_job_404(self, logged_in_client):
+        response = logged_in_client.get(f"/viewer/api/jobs/{uuid.uuid4()}")
+        assert response.status_code == 404
+
+    def test_foreign_job_403(self, client, db, uploaded_pdf, second_user):
+        job_id = db.create_job("ocr", uploaded_pdf, db.test_user_id)
+
+        login = client.post(
+            "/auth/login",
+            data={"username": "seconduser", "password": "secondpassword"},
+        )
+        assert login.status_code == 302
+
+        response = client.get(f"/viewer/api/jobs/{job_id}")
+        assert response.status_code == 403
+
+    def test_pending_job_status(self, logged_in_client, db, uploaded_pdf, user):
+        job_id = db.create_job("ocr", uploaded_pdf, user)
+
+        response = logged_in_client.get(f"/viewer/api/jobs/{job_id}")
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "pending"
+
+
+class TestOcrJobGuards:
+    def test_duplicate_active_ocr_job_409(
+        self, app, logged_in_client, db, uploaded_pdf, user, monkeypatch
+    ):
+        monkeypatch.setattr("pdf_annotator.services.ocr.ocr_available", lambda: True)
+        db.create_job("ocr", uploaded_pdf, user)  # stays pending
+
+        response = logged_in_client.post(f"/viewer/api/ocr/{uploaded_pdf}")
+        assert response.status_code == 409
+        assert "läuft bereits" in response.get_json()["error"]
+
+
+class TestDownloadEndpoint:
+    def test_download_pending_job_409(self, logged_in_client, db, uploaded_pdf, user):
+        job_id = db.create_job("export_pdf", uploaded_pdf, user)
+
+        response = logged_in_client.get(f"/export/download/{job_id}")
+        assert response.status_code == 409
+
+    def test_download_vanished_artifact_404(
+        self, logged_in_client, db, uploaded_pdf, user
+    ):
+        job_id = db.create_job("export_pdf", uploaded_pdf, user)
+        db.finish_job(job_id, "done", result_path="/nirgendwo/weg.pdf")
+
+        response = logged_in_client.get(f"/export/download/{job_id}")
+        assert response.status_code == 404
+
+
+class TestJobMaintenance:
+    def _age_job(self, db, job_id: str, seconds: int) -> None:
+        with db.get_connection() as conn:
+            conn.execute(
+                "UPDATE jobs SET created_at = datetime('now', ?),"
+                " finished_at = datetime('now', ?) WHERE id = ?",
+                (f"-{seconds} seconds", f"-{seconds} seconds", job_id),
+            )
+
+    def test_stale_running_job_flipped_to_error(self, db, uploaded_pdf, user):
+        job_id = db.create_job("ocr", uploaded_pdf, user)
+        db.mark_job_running(job_id)
+        self._age_job(db, job_id, jobs.JOB_STALE_SECONDS + 60)
+
+        flipped = db.mark_stale_jobs_failed(jobs.JOB_STALE_SECONDS)
+
+        assert flipped == 1
+        job = db.get_job(job_id)
+        assert job["status"] == "error"
+        assert "abgebrochen" in job["error"]
+
+    def test_fresh_running_job_untouched(self, db, uploaded_pdf, user):
+        job_id = db.create_job("ocr", uploaded_pdf, user)
+        db.mark_job_running(job_id)
+
+        assert db.mark_stale_jobs_failed(jobs.JOB_STALE_SECONDS) == 0
+        assert db.get_job(job_id)["status"] == "running"
+
+    def test_delete_finished_jobs_returns_artifact_paths(self, db, uploaded_pdf, user):
+        old_id = db.create_job("export_pdf", uploaded_pdf, user)
+        db.finish_job(old_id, "done", result_path="/tmp/alt.pdf")
+        self._age_job(db, old_id, 48 * 3600)
+
+        new_id = db.create_job("export_pdf", uploaded_pdf, user)
+        db.finish_job(new_id, "done", result_path="/tmp/neu.pdf")
+
+        paths = db.delete_finished_jobs(24 * 3600)
+
+        assert paths == ["/tmp/alt.pdf"]
+        assert db.get_job(old_id) is None
+        assert db.get_job(new_id) is not None

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,99 @@
+"""
+Tests for versioned schema migrations and the de-singletoned DatabaseManager.
+"""
+
+import sqlite3
+
+from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.migrations import MIGRATIONS, apply_migrations
+
+
+def _user_version(db_path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()
+
+
+class TestMigrations:
+    def test_fresh_db_is_stamped_to_latest_version(self, tmp_path):
+        db_path = tmp_path / "fresh.db"
+        DatabaseManager(db_path).init_db()
+
+        assert _user_version(db_path) == len(MIGRATIONS)
+
+    def test_init_db_is_idempotent(self, tmp_path):
+        db_path = tmp_path / "twice.db"
+        db = DatabaseManager(db_path)
+        db.init_db()
+        db.init_db()
+
+        assert _user_version(db_path) == len(MIGRATIONS)
+
+    def test_legacy_unversioned_db_migrates_and_keeps_data(self, tmp_path):
+        """A database created before versioning (user_version 0, partial
+        schema, existing rows) converges and is stamped."""
+        db_path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(db_path))
+        # Old-style users table without is_admin/theme columns.
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id TEXT PRIMARY KEY,
+                username TEXT NOT NULL UNIQUE,
+                email TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                is_active INTEGER DEFAULT 1
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO users (id, username, email, password_hash)"
+            " VALUES ('u1', 'alt', 'alt@example.com', 'hash')"
+        )
+        conn.commit()
+        conn.close()
+        assert _user_version(db_path) == 0
+
+        db = DatabaseManager(db_path)
+        db.init_db()
+
+        assert _user_version(db_path) == len(MIGRATIONS)
+        user = db.get_user_by_username("alt")
+        assert user is not None
+        assert user["email"] == "alt@example.com"
+        # Columns added by the baseline migration exist and default sanely.
+        assert user.get("is_admin") in (0, None, False)
+
+    def test_apply_migrations_runs_only_pending(self, tmp_path):
+        db_path = tmp_path / "pending.db"
+        conn = sqlite3.connect(str(db_path))
+        apply_migrations(conn)
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        # Re-running applies nothing and keeps the stamp.
+        apply_migrations(conn)
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == version
+        conn.close()
+
+
+class TestNoSingleton:
+    def test_two_instances_use_their_own_paths(self, tmp_path):
+        """Regression test for the old singleton, which ignored the path
+        passed to every constructor call after the first."""
+        db_a = DatabaseManager(tmp_path / "a.db")
+        db_b = DatabaseManager(tmp_path / "b.db")
+        db_a.init_db()
+        db_b.init_db()
+
+        db_a.create_user("nur_in_a", "a@example.com", "hash")
+
+        assert db_a.get_user_by_username("nur_in_a") is not None
+        assert db_b.get_user_by_username("nur_in_a") is None
+
+    def test_app_uses_configured_database(self, app):
+        from pdf_annotator.models.database import get_db
+
+        with app.app_context():
+            assert str(get_db()._db_path) == str(app.config["DATABASE_PATH"])

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import fitz
 
-from pdf_annotator.models.database import DatabaseManager
+from pdf_annotator.models.database import get_db
 from pdf_annotator.services.pdf_generator import (
     add_annotation_to_page,
     calculate_footer_rect,
@@ -155,7 +155,7 @@ class TestCreateAnnotatedPdf:
 
     def test_create_annotated_pdf_nonexistent_doc(self, app):
         with app.app_context():
-            db = DatabaseManager()
+            db = get_db()
 
             from pdf_annotator.services.pdf_generator import create_annotated_pdf
 

--- a/tests/test_pdf_processor.py
+++ b/tests/test_pdf_processor.py
@@ -1,16 +1,15 @@
 """
 Unit tests for PDF processor service.
 
-Tests PDF validation, page counting, rendering, and cache.
+Tests PDF validation, page counting, rendering, and text layout.
+The disk cache itself is covered in test_render_cache.py; outside an app
+context these functions render/extract uncached.
 """
 
 import fitz
 import pytest
 
 from pdf_annotator.services.pdf_processor import (
-    clear_render_cache,
-    clear_text_layout_cache,
-    get_cache_info,
     get_page_count,
     get_page_dimensions,
     get_page_text_layout,
@@ -58,9 +57,6 @@ class TestGetPageCount:
 class TestRenderPageToImage:
     """Test page rendering."""
 
-    def setup_method(self):
-        clear_render_cache()
-
     def test_render_valid_page(self, sample_pdf):
         result = render_page_to_image(str(sample_pdf), 1, dpi=72)
         assert result is not None
@@ -81,31 +77,8 @@ class TestRenderPageToImage:
         assert result is None
 
 
-class TestCache:
-    """Test render cache functions."""
-
-    def setup_method(self):
-        clear_render_cache()
-
-    def test_clear_cache(self, sample_pdf):
-        render_page_to_image(str(sample_pdf), 1, dpi=72)
-        clear_render_cache()
-        info = get_cache_info()
-        assert info["size"] == 0
-
-    def test_cache_info_structure(self):
-        info = get_cache_info()
-        assert "hits" in info
-        assert "misses" in info
-        assert "size" in info
-        assert "maxsize" in info
-
-
 class TestGetPageTextLayout:
     """Test word/bbox text extraction for the selectable text overlay."""
-
-    def setup_method(self):
-        clear_text_layout_cache()
 
     def test_page_dimensions_match_get_page_dimensions(self, sample_pdf):
         width, height = get_page_dimensions(sample_pdf, 1)
@@ -180,8 +153,3 @@ class TestGetPageTextLayout:
         assert marker["y0"] > layout["page_height"] / 2
         assert marker["x0"] < marker["x1"]
         assert marker["y0"] < marker["y1"]
-
-    def test_clear_text_layout_cache(self, sample_pdf):
-        get_page_text_layout(str(sample_pdf), 1)
-        clear_text_layout_cache()
-        assert get_page_text_layout.cache_info().currsize == 0

--- a/tests/test_render_cache.py
+++ b/tests/test_render_cache.py
@@ -1,0 +1,147 @@
+"""
+Tests for the shared disk render cache (services/render_cache.py) and its
+integration in pdf_processor.
+"""
+
+import os
+import time
+
+import fitz
+import pytest
+
+from pdf_annotator.services import pdf_processor, render_cache
+
+
+def _write_pdf(path, text: str) -> None:
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+    page.insert_text((72, 72), text, fontsize=24)
+    doc.save(str(path))
+    doc.close()
+
+
+@pytest.fixture()
+def counting_render(monkeypatch):
+    """Count actual renders behind the cache."""
+    calls = {"count": 0}
+    original = pdf_processor._render_page
+
+    def counted(file_path: str, page_num: int, dpi: int) -> bytes:
+        calls["count"] += 1
+        return original(file_path, page_num, dpi)
+
+    monkeypatch.setattr(pdf_processor, "_render_page", counted)
+    return calls
+
+
+class TestDiskCache:
+    def test_second_call_served_from_disk(
+        self, app, tmp_path, sample_pdf, counting_render
+    ):
+        with app.app_context():
+            first = pdf_processor.render_page_to_image(str(sample_pdf), 1, dpi=72)
+            second = pdf_processor.render_page_to_image(str(sample_pdf), 1, dpi=72)
+
+        assert first == second
+        assert counting_render["count"] == 1
+
+    def test_rewritten_pdf_renders_fresh_without_any_clear(
+        self, app, tmp_path, counting_render
+    ):
+        """The multi-worker regression: after a PDF is replaced/OCRed, no
+        worker may serve the old page image — with mtime/size keying that
+        holds without any explicit cache clearing."""
+        pdf_path = tmp_path / "mutating.pdf"
+        _write_pdf(pdf_path, "Version Eins")
+
+        with app.app_context():
+            before = pdf_processor.render_page_to_image(str(pdf_path), 1, dpi=72)
+
+            time.sleep(0.01)  # ensure a different mtime_ns
+            _write_pdf(pdf_path, "Version Zwei — ganz anderer Inhalt")
+
+            after = pdf_processor.render_page_to_image(str(pdf_path), 1, dpi=72)
+
+        assert counting_render["count"] == 2
+        assert before != after
+
+    def test_different_dpi_cached_separately(self, app, sample_pdf, counting_render):
+        with app.app_context():
+            pdf_processor.render_page_to_image(str(sample_pdf), 1, dpi=72)
+            pdf_processor.render_page_to_image(str(sample_pdf), 1, dpi=96)
+
+        assert counting_render["count"] == 2
+
+    def test_layout_round_trips_through_json_cache(self, app, sample_pdf):
+        with app.app_context():
+            first = pdf_processor.get_page_text_layout(str(sample_pdf), 1)
+            second = pdf_processor.get_page_text_layout(str(sample_pdf), 1)
+
+        assert first == second
+        words = [w["text"] for line in first["lines"] for w in line["words"]]
+        assert "Test" in words
+
+    def test_invalid_page_error_is_not_cached(self, app, sample_pdf):
+        with app.app_context():
+            with pytest.raises(ValueError):
+                pdf_processor.get_page_text_layout(str(sample_pdf), 99)
+            # No poisoned cache entry: valid pages still work.
+            layout = pdf_processor.get_page_text_layout(str(sample_pdf), 1)
+        assert layout["lines"]
+
+    def test_no_temp_files_left_behind(self, app, tmp_path, sample_pdf):
+        cache_dir = app.config["RENDER_CACHE_FOLDER"]
+        with app.app_context():
+            pdf_processor.render_page_to_image(str(sample_pdf), 1, dpi=72)
+            pdf_processor.get_page_text_layout(str(sample_pdf), 1)
+
+        leftovers = [p for p in cache_dir.rglob("*") if ".tmp-" in p.name]
+        assert leftovers == []
+
+    def test_uncached_outside_app_context(self, sample_pdf, counting_render):
+        assert pdf_processor.render_page_to_image(str(sample_pdf), 1, dpi=72)
+        assert pdf_processor.render_page_to_image(str(sample_pdf), 1, dpi=72)
+        assert counting_render["count"] == 2
+
+
+class TestPrune:
+    def _entry(self, cache_dir, name: str, size: int, age_seconds: int):
+        path = cache_dir / name[:2] / name / "page1@72.png"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"x" * size)
+        stamp = time.time() - age_seconds
+        os.utime(path, (stamp, stamp))
+        return path
+
+    def test_prunes_oldest_first_until_under_budget(self, tmp_path):
+        cache_dir = tmp_path / "cache"
+        old = self._entry(cache_dir, "aa11", 600, age_seconds=3600)
+        new = self._entry(cache_dir, "bb22", 600, age_seconds=60)
+
+        freed = render_cache.prune(cache_dir, max_bytes=1000)
+
+        assert freed == 600
+        assert not old.exists()
+        assert new.exists()
+
+    def test_no_prune_when_under_budget(self, tmp_path):
+        cache_dir = tmp_path / "cache"
+        entry = self._entry(cache_dir, "cc33", 100, age_seconds=3600)
+
+        assert render_cache.prune(cache_dir, max_bytes=1000) == 0
+        assert entry.exists()
+
+    def test_removes_stale_temp_files_and_empty_dirs(self, tmp_path):
+        cache_dir = tmp_path / "cache"
+        entry = self._entry(cache_dir, "dd44", 600, age_seconds=3600)
+        tmp_file = entry.with_name("page1@72.png.tmp-123-abc")
+        tmp_file.write_bytes(b"partial")
+
+        render_cache.prune(cache_dir, max_bytes=0)
+
+        assert not tmp_file.exists()
+        assert not entry.exists()
+        assert not entry.parent.exists()  # emptied digest dir removed
+
+    def test_missing_cache_dir_is_noop(self, tmp_path):
+        assert render_cache.prune(tmp_path / "nichts", max_bytes=100) == 0

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -158,14 +158,20 @@ class TestPageTextApi:
 class TestOcrApi:
     """Test the OCR endpoint (OCR run itself is mocked — no tesseract in CI)."""
 
-    def test_ocr_success(self, app, logged_in_client, uploaded_pdf, monkeypatch):
+    def test_ocr_success(
+        self, app, logged_in_client, uploaded_pdf, monkeypatch, inline_jobs
+    ):
         monkeypatch.setattr("pdf_annotator.services.ocr.ocr_available", lambda: True)
         monkeypatch.setattr(
             "pdf_annotator.services.ocr.ocr_pdf", lambda file_path: None
         )
         response = logged_in_client.post(f"/viewer/api/ocr/{uploaded_pdf}")
-        assert response.status_code == 200
-        assert response.get_json()["success"] is True
+        assert response.status_code == 202
+        job_id = response.get_json()["job_id"]
+
+        status = logged_in_client.get(f"/viewer/api/jobs/{job_id}")
+        assert status.status_code == 200
+        assert status.get_json()["status"] == "done"
 
     def test_ocr_unavailable_returns_501(
         self, app, logged_in_client, uploaded_pdf, monkeypatch
@@ -174,8 +180,8 @@ class TestOcrApi:
         response = logged_in_client.post(f"/viewer/api/ocr/{uploaded_pdf}")
         assert response.status_code == 501
 
-    def test_ocr_failure_returns_500(
-        self, app, logged_in_client, uploaded_pdf, monkeypatch
+    def test_ocr_failure_reported_via_job_status(
+        self, app, logged_in_client, uploaded_pdf, monkeypatch, inline_jobs
     ):
         from pdf_annotator.services.ocr import OCRError
 
@@ -185,7 +191,12 @@ class TestOcrApi:
         monkeypatch.setattr("pdf_annotator.services.ocr.ocr_available", lambda: True)
         monkeypatch.setattr("pdf_annotator.services.ocr.ocr_pdf", raise_error)
         response = logged_in_client.post(f"/viewer/api/ocr/{uploaded_pdf}")
-        assert response.status_code == 500
+        assert response.status_code == 202
+        job_id = response.get_json()["job_id"]
+
+        status = logged_in_client.get(f"/viewer/api/jobs/{job_id}").get_json()
+        assert status["status"] == "error"
+        assert status["error"] == "boom"
 
     def test_ocr_invalid_doc(self, logged_in_client):
         response = logged_in_client.post("/viewer/api/ocr/not-a-uuid")
@@ -338,7 +349,7 @@ class TestDeletePage:
 class TestExportRoutes:
     """Test PDF and Markdown export."""
 
-    def test_export_pdf(self, app, logged_in_client, uploaded_pdf):
+    def test_export_pdf(self, app, logged_in_client, uploaded_pdf, inline_jobs):
         # Add an annotation first
         logged_in_client.post(
             f"/viewer/api/annotation/{uploaded_pdf}/1",
@@ -347,8 +358,16 @@ class TestExportRoutes:
         )
 
         response = logged_in_client.post(f"/export/pdf/{uploaded_pdf}")
-        assert response.status_code == 200
-        assert response.content_type == "application/pdf"
+        assert response.status_code == 202
+        job_id = response.get_json()["job_id"]
+
+        status = logged_in_client.get(f"/viewer/api/jobs/{job_id}").get_json()
+        assert status["status"] == "done"
+        assert status["result"]["filename"].endswith(".pdf")
+
+        download = logged_in_client.get(f"/export/download/{job_id}")
+        assert download.status_code == 200
+        assert download.content_type == "application/pdf"
 
     def test_export_markdown(self, app, logged_in_client, uploaded_pdf):
         # Add an annotation first
@@ -386,14 +405,18 @@ class TestDesktopModeExports:
     Content-Disposition: attachment responses."""
 
     def test_export_pdf_desktop_mode(
-        self, app, logged_in_client, uploaded_pdf, tmp_path, monkeypatch
+        self, app, logged_in_client, uploaded_pdf, tmp_path, monkeypatch, inline_jobs
     ):
         monkeypatch.setitem(app.config, "DESKTOP_MODE", True)
         monkeypatch.setitem(app.config, "DESKTOP_EXPORT_DIR", tmp_path)
 
         response = logged_in_client.post(f"/export/pdf/{uploaded_pdf}")
-        assert response.status_code == 200
-        data = response.get_json()
+        assert response.status_code == 202
+        job_id = response.get_json()["job_id"]
+
+        download = logged_in_client.get(f"/export/download/{job_id}")
+        assert download.status_code == 200
+        data = download.get_json()
         assert data["success"] is True
         assert Path(data["path"]).exists()
         assert Path(data["path"]).parent == tmp_path


### PR DESCRIPTION
## Summary

This PR refactors the application's database layer from a singleton pattern to a factory function, introduces a background job system for long-running operations (PDF export, OCR), adds versioned schema migrations, implements a disk-based render cache, and consolidates error handling across routes.

## Key Changes

**Database & Migrations**
- Converted `DatabaseManager` from singleton to regular class; added `get_db()` factory function stored in `app.extensions["db"]`
- Introduced versioned schema migrations in `models/migrations.py` tracked via `PRAGMA user_version`
- Made database operations thread-safe with per-operation connections and WAL mode pragmas
- Removed manual singleton reset from test fixtures

**Background Jobs**
- Added `services/jobs.py` with in-process `ThreadPoolExecutor` for long-running work (OCR, PDF export)
- Jobs persist status/results in new `jobs` table; clients poll via `/job/<job_id>` endpoint
- Integrated job submission into export and OCR routes
- Added `services/cleanup.py` daemon thread to expire old jobs, clean exports, and prune render cache

**Render Cache**
- Replaced per-process `@lru_cache` with disk-based cache in `services/render_cache.py`
- Cache keys derived from file path + mtime + size; mutations automatically invalidate stale entries
- Atomic writes prevent corruption from concurrent workers
- Pruning by cleanup thread respects configurable size budget

**Error Handling & Helpers**
- Created `routes/_helpers.py` with `@handle_errors()` decorator for content-negotiating error responses (JSON for API paths, HTML for pages)
- Extracted `get_owned_document()` helper to validate doc_id, fetch document, and verify ownership in one call
- Removed repetitive try-catch and validation boilerplate from all route handlers

**Forms & Auth**
- Added `forms.py` with Flask-WTF form classes (`LoginForm`, `RegisterForm`, `ChangePasswordForm`)
- Validation rules and German error messages mirror previous hand-rolled checks exactly
- Auth routes now use form validation instead of manual request parsing

**Configuration & Deployment**
- Added persistent `SECRET_KEY` generation in `config.py` (stored in `<data_dir>/secret_key` with 0600 permissions)
- Sessions now survive restarts and are consistent across Gunicorn workers
- Added `PDF_ANNOTATOR_BEHIND_PROXY` flag for reverse proxy deployments
- Updated deployment checklist and Docker Compose examples

**Testing**
- Added comprehensive test suites: `test_jobs.py`, `test_cleanup.py`, `test_render_cache.py`, `test_migrations.py`, `test_forms.py`, `test_config.py`, `test_error_handlers.py`
- Removed singleton reset fixture; tests now create fresh `DatabaseManager` instances
- Added `inline_jobs` fixture to run jobs synchronously in tests

**Documentation**
- Updated `ref/architecture.md` with new job system and cleanup thread
- Added `ref/django-migration-feasibility.md` analysis
- Updated `ref/database.md` and `ref/services.md` to document migrations and cache

## Notable Implementation Details

- **Thread Safety**: Database uses WAL mode + per-operation connections; no global locks needed. Cleanup thread uses non-blocking file lock to skip redundant work in multi-worker setups.
- **Idempotent Operations**: All cleanup tasks (export deletion, job expiry, cache pruning) are idempotent; correctness doesn't depend on exclusion.
- **Cache Invalidation**: Disk cache automatically invalidates when PDF is modified (mtime/size change), eliminating need for cross-process invalidation signals.
- **Error Negotiation**: Single `@handle_errors()` decorator replaces dozens of try-catch blocks; automatically chooses JSON or HTML based on request path.
- **Job Polling**: Frontend uses `jobs.js` helper to poll job status; export/OCR endpoints return job ID immediately instead of blocking.

https://claude.ai/code/session_01TpejHefpawhUNEcskPPkp5